### PR TITLE
Add headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ sendspin --static-delay-ms -100
 
 > **Note:** Based on limited testing, the delay value is typically a negative number (e.g., `-100` or `-150`) to compensate for audio hardware buffering.
 
+### Headless Mode
+
+To run the player without the interactive terminal UI (useful for background services or scripts):
+
+```bash
+sendspin --headless
+```
+
+In headless mode, status messages are printed to stdout instead of the TUI.
+
 ### Debugging & Troubleshooting
 
 If you experience synchronization issues or audio glitches, you can enable detailed logging to help diagnose the problem:

--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -62,6 +62,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Discover and list available Sendspin servers on the network",
     )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run without the interactive terminal UI",
+    )
     return parser.parse_args(argv)
 
 
@@ -130,6 +135,7 @@ def main() -> int:
         static_delay_ms=args.static_delay_ms,
         audio_device=args.audio_device,
         log_level=args.log_level,
+        headless=args.headless,
     )
 
     # Run the application


### PR DESCRIPTION
Add `--headless` flag to get the old behavior back.

<img width="439" height="168" alt="image" src="https://github.com/user-attachments/assets/989e6089-b431-49da-978b-2df2aa4b06d6" />
