### PR TITLE
Serve always loop and fix looping overlap

### DIFF
--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -42,11 +42,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default="Sendspin Server",
         help="Server name for mDNS discovery",
     )
-    serve_parser.add_argument(
-        "--loop",
-        action="store_true",
-        help="Loop the audio source continuously",
-    )
 
     # Default behavior (client mode) - existing arguments
     parser.add_argument(
@@ -170,7 +165,6 @@ def main() -> int:
             source=source,
             port=args.port,
             name=args.name,
-            loop=args.loop,
         )
         try:
             return asyncio.run(run_server(config))

--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -54,7 +54,6 @@ class ServeConfig:
     source: str
     port: int = 8927
     name: str = "Sendspin Server"
-    loop: bool = False
 
 
 async def run_server(config: ServeConfig) -> int:


### PR DESCRIPTION
We had a loop keyword arg but actually always looped anyway. So dropped it.

When looping a local MP3, it was overlapping the end of the song with the looped new song starting. This PR fixes that and also cleans up the source handling.