### PR TITLE
Disable auto reconnect for serve UI

### DIFF
--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -66,6 +66,13 @@ async function initPlayer() {
 function updateSyncStatus() {
   if (!player) return;
 
+  // SDK has no way to control reconnect logic or inform us of disconnects yet
+  // But since we check this ever 500ms, it's good enough for now
+  if (!player.isConnected) {
+    disconnect();
+    return;
+  }
+
   const syncInfo = player.syncInfo;
   if (syncInfo?.syncErrorMs !== undefined) {
     const syncMs = syncInfo.syncErrorMs;


### PR DESCRIPTION
The Serve UI will no longer automatically try to reconnect when the connection is lost. Let the user opt-in to listen again.