### PR TITLE
Handle exception on Windows

### DIFF
--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -77,6 +77,7 @@ async def run_server(config: ServeConfig) -> int:
     event_loop = asyncio.get_event_loop()
 
     # On Windows, suppress ConnectionResetError during client disconnect
+    # Background: https://github.com/Sendspin/sendspin-cli/pull/26
     if sys.platform == "win32":
         event_loop.set_exception_handler(_windows_exception_handler)
 


### PR DESCRIPTION
On Windows in ReactorLoop in asyncio, calling shutdown on a closed socket raises an exception that is logged as unhandled. It's harmless but better to not show it at all.

<img width="1483" height="762" alt="image" src="https://github.com/user-attachments/assets/d22a0eba-3a0d-47ce-9223-0370ee869ec7" />
