### PR TITLE
Update Sendspin protocol spec link and add reference note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 ## Project Overview
 
-Sendspin CLI is a synchronized audio player client for the [Sendspin Protocol](https://github.com/Sendspin-Protocol/spec). It connects to Sendspin servers via WebSocket, receives time-synchronized audio streams, and plays them back with precise timing to enable multi-room synchronized audio.
+Sendspin CLI is a synchronized audio player client for the [Sendspin Protocol](https://github.com/Sendspin/website/blob/main/src/spec.md). It connects to Sendspin servers via WebSocket, receives time-synchronized audio streams, and plays them back with precise timing to enable multi-room synchronized audio.
+
+**Note**: If uncertain about how something in Sendspin is supposed to work, fetch and refer to the [protocol specification](https://github.com/Sendspin/website/blob/main/src/spec.md) for authoritative implementation details.
 
 ## Architecture
 


### PR DESCRIPTION
- Update spec link to point to the canonical location in the website repo
- Add note to fetch the spec when uncertain about implementation details