### PR TITLE
Refactor: Clean up app initialization and connection handling

### DIFF
--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -6,9 +6,7 @@ import asyncio
 import contextlib
 import logging
 import signal
-import socket
 from dataclasses import dataclass
-from functools import partial
 
 from aiohttp import ClientError
 from aiosendspin.client import SendspinClient
@@ -29,9 +27,9 @@ class DaemonConfig:
     """Configuration for the Sendspin daemon."""
 
     audio_device: AudioDevice
+    client_id: str
+    client_name: str
     url: str | None = None
-    client_id: str | None = None
-    client_name: str | None = None
     static_delay_ms: float = 0.0
 
 
@@ -41,34 +39,9 @@ class SendspinDaemon:
     def __init__(self, config: DaemonConfig) -> None:
         """Initialize the daemon."""
         self._config = config
-        self._client: SendspinClient | None = None
-        self._audio_handler: AudioStreamHandler | None = None
-        self._discovery: ServiceDiscovery | None = None
-        self._shutdown_event: asyncio.Event | None = None
-
-    async def run(self) -> int:
-        """Run the daemon."""
-        config = self._config
-
-        # Get hostname for defaults if needed
-        client_id = config.client_id
-        client_name = config.client_name
-        if client_id is None or client_name is None:
-            hostname = socket.gethostname()
-            if not hostname:
-                logger.error("Unable to determine hostname. Please specify --id and/or --name")
-                return 1
-            # Auto-generate client ID and name from hostname
-            if client_id is None:
-                client_id = f"sendspin-cli-{hostname}"
-            if client_name is None:
-                client_name = hostname
-
-        logger.info("Starting Sendspin daemon: %s", client_id)
-
         self._client = SendspinClient(
-            client_id=client_id,
-            client_name=client_name,
+            client_id=config.client_id,
+            client_name=config.client_name,
             roles=[Roles.PLAYER],
             device_info=get_device_info(),
             player_support=ClientHelloPlayerSupport(
@@ -85,90 +58,62 @@ class SendspinDaemon:
             ),
             static_delay_ms=config.static_delay_ms,
         )
-
+        self._audio_handler = AudioStreamHandler(audio_device=config.audio_device)
         self._discovery = ServiceDiscovery()
+        self._shutdown_event = asyncio.Event()
+
+    async def run(self) -> int:
+        """Run the daemon."""
+        logger.info("Starting Sendspin daemon: %s", self._client._client_id)
+        url = self._config.url
+        loop = asyncio.get_running_loop()
+
+        def signal_handler() -> None:
+            logger.debug("Received interrupt signal, shutting down...")
+            self._shutdown_event.set()
+
+        # Register signal handlers
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(signal.SIGINT, signal_handler)
+            loop.add_signal_handler(signal.SIGTERM, signal_handler)
+
         await self._discovery.start()
 
         try:
-            # Get initial server URL
-            url = config.url
             if url is None:
                 logger.info("Waiting for mDNS discovery of Sendspin server...")
-                try:
-                    url = await self._discovery.wait_for_first_server()
-                    logger.info("Discovered Sendspin server at %s", url)
-                except asyncio.CancelledError:
-                    return 1
-                except Exception:
-                    logger.exception("Failed to discover server")
-                    return 1
-
-            logger.info(
-                "Using audio device %d: %s",
-                config.audio_device.index,
-                config.audio_device.name,
-            )
+                url = await self._discover_server()
+                if self._shutdown_event.is_set():
+                    return 0
 
             listeners = ClientListenerManager()
-
-            self._audio_handler = AudioStreamHandler(audio_device=config.audio_device)
             self._audio_handler.attach_client(self._client, listeners)
-
             listeners.attach(self._client)
 
-            loop = asyncio.get_running_loop()
-
-            self._shutdown_event = asyncio.Event()
-
-            def signal_handler() -> None:
-                logger.debug("Received interrupt signal, shutting down...")
-                if self._shutdown_event is not None:
-                    self._shutdown_event.set()
-
-            # Register signal handlers
-            with contextlib.suppress(NotImplementedError):
-                loop.add_signal_handler(signal.SIGINT, signal_handler)
-                loop.add_signal_handler(signal.SIGTERM, signal_handler)
-
-            try:
-                await self._connection_loop(url, use_discovery=config.url is None)
-            finally:
-                # Remove signal handlers
-                with contextlib.suppress(NotImplementedError):
-                    loop.remove_signal_handler(signal.SIGINT)
-                    loop.remove_signal_handler(signal.SIGTERM)
-                await self._audio_handler.cleanup()
-                await self._client.disconnect()
-                logger.info("Daemon stopped")
+            await self._connection_loop(url, use_discovery=self._config.url is None)
 
         finally:
-            # Stop discovery
+            await self._audio_handler.cleanup()
+            await self._client.disconnect()
             await self._discovery.stop()
+            logger.info("Daemon stopped")
 
         return 0
 
     async def _connection_loop(self, initial_url: str, use_discovery: bool) -> None:
         """Run the connection loop with automatic reconnection."""
-        assert self._client is not None
-        assert self._discovery is not None
-        assert self._audio_handler is not None
-        assert self._shutdown_event is not None
-
         url = initial_url
         error_backoff = 1.0
         max_backoff = 300.0
+        disconnect_event = asyncio.Event()
+        self._client.set_disconnect_listener(disconnect_event.set)
 
         while not self._shutdown_event.is_set():
+            disconnect_event.clear()
+
             try:
-                logger.info("Connecting to %s", url)
                 await self._client.connect(url)
-                logger.info("Connected to %s", url)
                 error_backoff = 1.0
-
-                # Wait for disconnect or shutdown
-                disconnect_event = asyncio.Event()
-                self._client.set_disconnect_listener(partial(asyncio.Event.set, disconnect_event))
-
                 shutdown_task = create_task(self._shutdown_event.wait())
                 disconnect_task = create_task(disconnect_event.wait())
 
@@ -182,8 +127,6 @@ class SendspinDaemon:
                     with contextlib.suppress(asyncio.CancelledError):
                         await task
 
-                self._client.set_disconnect_listener(None)
-
                 if shutdown_task in done:
                     break
 
@@ -192,21 +135,7 @@ class SendspinDaemon:
                 await self._audio_handler.cleanup()
 
                 if use_discovery:
-                    # Try to get new URL from discovery, or use last known URL
-                    new_url = self._discovery.current_url()
-                    if new_url:
-                        url = new_url
-
-                    # Wait for server to reappear if discovery shows nothing
-                    if not self._discovery.current_url():
-                        logger.info("Server offline, waiting for rediscovery...")
-                        while not self._shutdown_event.is_set():
-                            new_url = self._discovery.current_url()
-                            if new_url:
-                                url = new_url
-                                break
-                            await asyncio.sleep(1.0)
-
+                    url = await self._discover_server()
                     if self._shutdown_event.is_set():
                         break
 
@@ -227,8 +156,8 @@ class SendspinDaemon:
                     pass  # Sleep completed, continue loop
 
                 # Check if URL changed while sleeping (only when using discovery)
-                if use_discovery:
-                    new_url = self._discovery.current_url()
+                if use_discovery and (servers := self._discovery.get_servers()):
+                    new_url = servers[0].url
                     if new_url and new_url != url:
                         logger.info("Server URL changed to %s", new_url)
                         url = new_url
@@ -239,9 +168,24 @@ class SendspinDaemon:
 
             except Exception:
                 logger.exception("Unexpected error during connection")
-                try:
-                    await asyncio.wait_for(self._shutdown_event.wait(), timeout=error_backoff)
-                    break
-                except TimeoutError:
-                    pass
-                error_backoff = min(error_backoff * 2, max_backoff)
+                break
+
+    async def _discover_server(self) -> str:
+        """Discover next server to use.
+
+        Returns empty string when shutdown is set.
+        """
+        next_server_task = create_task(self._discovery.wait_for_server())
+
+        if not next_server_task.done():
+            shutdown_task = create_task(self._shutdown_event.wait())
+            await asyncio.wait(
+                {shutdown_task, next_server_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+        if self._shutdown_event.is_set():
+            return ""
+
+        server = await next_server_task
+        return server.url


### PR DESCRIPTION
## Summary

- Move client ID/name resolution from app classes to CLI layer
- Create app dependencies in `__init__` instead of `run()` for better testability
- Consolidate connection loop as a method on `SendspinApp` and `SendspinDaemon`
- Use `DiscoveredServer` objects throughout instead of raw URLs

## Changes

### CLI Layer (`cli.py`)
- Add `_resolve_client_info()` to centralize client ID/name resolution with proper error handling
- Make `_run_daemon_mode` and `_run_client_mode` async, with single `asyncio.run()` at entry point

### App Initialization
- `SendspinApp` and `SendspinDaemon` now create `SendspinClient`, `AudioStreamHandler`, `ServiceDiscovery`, and `ConnectionManager` in `__init__`
- `AppConfig` and `DaemonConfig` now require `client_id` and `client_name` (no longer optional)
- `SendspinUI` now takes `delay_ms` in constructor

### Connection Handling
- Move `connection_loop` from standalone function to `_connection_loop` method on `SendspinApp`
- Convert standalone handler functions (`_handle_metadata_update`, `_handle_group_update`, etc.) to methods
- Simplify `ConnectionManager` by using `DiscoveredServer` objects instead of URL strings

### Discovery (`discovery.py`)
- Add `DiscoveredServer.from_url()` factory method for creating server objects from CLI URLs
- Replace `current_url()` and `wait_for_first_server()` with unified `wait_for_server()` that returns `DiscoveredServer`
- Remove unused `_current_url` tracking

### Other
- Simplify `sleep_interruptible` using `asyncio.wait` with timeout instead of polling loop
- Remove redundant assertions on fields that are always set in `__init__`

## Result

~125 lines removed while improving code organization and testability.