### PR TITLE
Raspberry Pi 0 fix - Extending usage of "Thread-safe snapshot"

### DIFF
--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -471,11 +471,11 @@ class AudioPlayer:
 
                         # Handle correction event if at boundary
                         if frames_remaining > 0:
-                            if drop_counter <= 0 and self._drop_every_n_frames > 0:
+                            if drop_counter <= 0 and drop_every_n > 0:
                                 # Drop frame: read EXTRA frame to advance cursor faster
                                 _ = self._read_one_input_frame()  # Read frame we're replacing
                                 _ = self._read_one_input_frame()  # Read frame we're DROPPING
-                                drop_counter = self._drop_every_n_frames
+                                drop_counter = drop_every_n
                                 self._frames_dropped_since_log += 1
                                 # Output last frame instead (don't output either frame we read)
                                 output_buffer[bytes_written : bytes_written + frame_size] = (
@@ -484,10 +484,10 @@ class AudioPlayer:
                                 bytes_written += frame_size
                                 frames_remaining -= 1
                                 insert_counter -= 1
-                            elif insert_counter <= 0 and self._insert_every_n_frames > 0:
+                            elif insert_counter <= 0 and insert_every_n > 0:
                                 # Insert frame: output duplicate WITHOUT reading
                                 # This makes playback catch up to cursor (cursor doesn't advance)
-                                insert_counter = self._insert_every_n_frames
+                                insert_counter = insert_every_n
                                 self._frames_inserted_since_log += 1
                                 output_buffer[bytes_written : bytes_written + frame_size] = (
                                     self._last_output_frame


### PR DESCRIPTION
The Raspberry Pi 0 (variant of the original Raspberry Pi) is a low performant, single-threaded computer.

Accordingly, it's a bit more sensitive to some time based issues.

You snapshot `self._####_every_n_frames` from what I assume is the same general issue, giving the comment `Thread-safe snapshot of correction schedule`

However, the replacement `####_every_n` aren't used in all spots within the loop.

This update to use these seems to have resolved the playback issues on the Raspi 0.


My issue manifested itself as switching from 7% CPU to 100% CPU and hanging. 

Identified with `py-spy`
Disclosure: chatgpt was used to summarize the code.


## Note Not Just the RPi0:
Yes, yes, this is (more) applicable to all low performant single-threaded computers, but I'm working on an RPi0 right now.

## Note to non-maintainers who stumble on this from key words.
Yes, pypi doesn't have many python wheel deps, but [piwheels](https://piwheels.org/) does.  For the ones it doesn't have, you can find a copy of them in my [playground repo](https://github.com/Joldiges/debra/tree/main/legacy/raspi0/wheels)
Or better yet, don't trust me and [build them yourself](https://github.com/Joldiges/debra/tree/main/legacy/wheelbuilder).  I have a dockerfile and helper script to emulate the architecture so you can build.