### PR TITLE
Fix TUI reconnection when --url is specified

### DIFF
--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -375,6 +375,12 @@ class SendspinApp:
                     ui.set_disconnected(f"Switching to {url}...")
                     continue
 
+                # If URL was provided via --url, reconnect directly without mDNS
+                if self._config.url:
+                    ui.add_event(f"Reconnecting to {url}...")
+                    ui.set_disconnected(f"Reconnecting to {url}...")
+                    continue
+
                 # Update URL from discovery
                 server = servers[0] if (servers := discovery.get_servers()) else None
 


### PR DESCRIPTION
## Summary

- Skip mDNS discovery on reconnect when URL was provided via `--url` command line argument
- Matches the existing daemon mode behavior which correctly handles this case

Fixes #39