### PR TITLE
Add OpenGraph metadata tags to serve website

### DIFF
--- a/sendspin/serve/web/index.html
+++ b/sendspin/serve/web/index.html
@@ -7,8 +7,6 @@
     <meta property="og:title" content="Sendspin Party" />
     <meta property="og:description" content="Experience multi-room audio with Sendspin - perfectly synchronized audio streaming across all your devices using the open Sendspin protocol." />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Sendspin" />
-    <meta property="og:locale" content="en_US" />
     <link rel="stylesheet" href="styles.css" />
     <script src="https://unpkg.com/qrcode-generator@1.4.4/qrcode.js"></script>
   </head>


### PR DESCRIPTION
Added OG tags to enable proper social media previews:
- og:title, og:description, og:type
- og:site_name, og:locale

The tags describe the Sendspin Party multi-room audio experience
and will display correctly when shared on social platforms.