### PR TITLE
chnage default volume to 25

### DIFF
--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -200,7 +200,7 @@ class AudioPlayer:
         self._stream_started = False
         self._first_real_chunk = True  # Flag to initialize timing from first chunk
 
-        self._volume: int = 100  # 0-100 range
+        self._volume: int = 25  # 0-100 range
         self._muted: bool = False
 
         # Partial chunk tracking (to avoid discarding partial chunks)

--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -59,7 +59,7 @@ class AppState:
     album: str | None = None
     track_progress: int | None = None
     track_duration: int | None = None
-    player_volume: int = 100
+    player_volume: int = 25 # Default player volume
     player_muted: bool = False
     group_id: str | None = None
 

--- a/sendspin/tui/ui.py
+++ b/sendspin/tui/ui.py
@@ -58,7 +58,7 @@ class UIState:
     # Volume
     volume: int | None = None
     muted: bool = False
-    player_volume: int = 100
+    player_volume: int = 25 # Default player volume
     player_muted: bool = False
 
     # Delay


### PR DESCRIPTION
Currently the cli player resets to 100 every time it starts. I've changed the default to player volume to 25. 

It's an arbitrary value, but meant to prevent someone from accidentally starting a new session at full volume. 

Ideally, the player would get a full state sync from the server and fall back to the previous volume (if there was one). But, this should help in the meantime. 