### PR TITLE
Handle FileNotFoundError in serve mode gracefully

### DIFF
--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -205,6 +205,9 @@ async def run_server(config: ServeConfig) -> int:
                 await play_media_task
             except asyncio.CancelledError:
                 pass
+            except FileNotFoundError as e:
+                print(f"Error: {e}")
+                return 1
             except Exception as e:
                 print(f"Playback error: {e}")
                 logger.debug("Playback error", exc_info=True)


### PR DESCRIPTION
## Summary
- Exit with error code 1 and a clean message when the source file doesn't exist
- Instead of showing a full traceback, displays: `Error: [Errno 2] No such file or directory: '/path/to/file'`

## Dependencies
- Requires Sendspin/aiosendspin#128 to be merged first

## Test plan
- [ ] Test `sendspin serve /nonexistent/file.mp3` - should show clean error and exit with code 1
- [ ] Test `sendspin serve /valid/file.mp3` - should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)