### PR TITLE
Refactor server event callback from async to sync

### DIFF
--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -110,7 +110,7 @@ async def run_server(config: ServeConfig) -> int:
     with suppress(NotImplementedError):
         event_loop.add_signal_handler(signal.SIGINT, handle_sigint)
 
-    async def on_server_event(server: SendspinServer, event: SendspinEvent) -> None:
+    def on_server_event(server: SendspinServer, event: SendspinEvent) -> None:
         nonlocal active_group
 
         if isinstance(event, ClientAddedEvent):
@@ -124,7 +124,7 @@ async def run_server(config: ServeConfig) -> int:
                 client_connected.set()
                 return
 
-            await active_group.add_client(client)
+            create_task(active_group.add_client(client))
 
         if isinstance(event, ClientRemovedEvent):
             if active_group is None:


### PR DESCRIPTION
## Summary
- Update server event listener callback to be synchronous instead of async

This PR prepares sendspin-cli for the next aiosendspin release which includes breaking changes to event listener callbacks.

**Breaking change PR:** https://github.com/Sendspin/aiosendspin/pull/115

## Test plan
- [ ] Wait for aiosendspin release with PR #115 merged
- [x] Verify serve mode still works correctly with client connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)