### PR TITLE
Upgrade sendspin installation command

### DIFF
--- a/scripts/systemd/install-systemd.sh
+++ b/scripts/systemd/install-systemd.sh
@@ -118,7 +118,7 @@ fi
 
 # Install sendspin
 echo -e "\n${D}Installing sendspin...${N}"
-sudo -u "$USER" bash -l -c "uv tool install sendspin" || { echo -e "${R}Failed${N}"; exit 1; }
+sudo -u "$USER" bash -l -c "uv tool install --upgrade sendspin" || { echo -e "${R}Failed${N}"; exit 1; }
 
 # Grab the proper bin path from uv (in case it's non-standard)
 SENDSPIN_BIN="$(sudo -u "$USER" bash -l -c "uv tool dir --bin")/sendspin"


### PR DESCRIPTION
If the sendspin tool is already installed, make sure it is upgraded to the latest version (to avoid #76) 