### PR TITLE
Change default client port from 8927 to 8928

### DIFF
--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -84,7 +84,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--port",
         type=int,
         default=None,
-        help="Port to listen on (default: 8927)",
+        help="Port to listen on (default: 8928)",
     )
     serve_parser.add_argument(
         "--name",
@@ -127,7 +127,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--port",
         type=int,
         default=None,
-        help="Port to listen on for incoming server connections (default: 8927)",
+        help="Port to listen on for incoming server connections (default: 8928)",
     )
     daemon_parser.add_argument(
         "--name",
@@ -318,7 +318,7 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
 
     # Apply settings defaults
     if args.port is None:
-        args.port = settings.listen_port or 8927
+        args.port = settings.listen_port or 8928
     if args.name is None:
         args.name = settings.name or "Sendspin Server"
     if args.log_level is None:
@@ -427,7 +427,7 @@ async def _run_client_mode(args: argparse.Namespace) -> int:
     if args.log_level is None:
         args.log_level = settings.log_level or "INFO"
     if args.command == "daemon" and args.port is None:
-        args.port = settings.listen_port or 8927
+        args.port = settings.listen_port or 8928
     args.use_mpris = not getattr(args, "disable_mpris", False) and settings.use_mpris
 
     # Set up logging with resolved log level

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -43,7 +43,7 @@ class DaemonArgs:
     settings: ClientSettings
     url: str | None = None
     static_delay_ms: float | None = None
-    listen_port: int = 8927
+    listen_port: int = 8928
     use_mpris: bool = True
 
 

--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -56,7 +56,7 @@ class ServeConfig:
     """Configuration for the serve command."""
 
     source: str
-    port: int = 8927
+    port: int = 8928
     name: str = "Sendspin Server"
     clients: list[str] | None = None
 


### PR DESCRIPTION
## Summary
- Update default port from 8927 to 8928

Waiting for https://github.com/Sendspin/spec/pull/62

🤖 Generated with [Claude Code](https://claude.com/claude-code)