### PR TITLE
Fix spurious handshake timeout when two servers connect at same time

### DIFF
--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -201,9 +201,7 @@ class SendspinDaemon:
             # Clean up any previous client
             if self._client is not None:
                 logger.info("Disconnecting from previous server")
-                if self._mpris is not None:
-                    self._mpris.stop()
-                await self._audio_handler.cleanup()
+                await self._stop_mpris_and_audio()
                 if self._client.connected:
                     try:
                         await self._client._send_message(  # noqa: SLF001
@@ -252,7 +250,7 @@ class SendspinDaemon:
         finally:
             # Only cleanup if we're still the active client (not replaced by new connection)
             if self._client is client:
-                await self._audio_handler.cleanup()
+                await self._stop_mpris_and_audio()
 
     async def _connection_loop(self, url: str) -> None:
         """Run the connection loop with automatic reconnection (client-initiated mode)."""


### PR DESCRIPTION
## Summary
- Fix spurious "Handshake with server timed out" warning when two servers connect in quick succession
- Use asyncio.Lock to serialize connection handling, ensuring in-progress handshakes complete before switching
- Properly send goodbye message to previous server before disconnecting

## Test plan
- [x] Run `sendspin daemon` and have two servers connect in quick succession
- [x] Verify no timeout warning appears
- [x] Verify the second server connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)