### PR TITLE
Remove iOS mute switch warning

### DIFF
--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -19,7 +19,6 @@ const elements = {
   shareBtn: document.getElementById("share-btn"),
   shareServerUrl: document.getElementById("share-server-url"),
   castLink: document.getElementById("cast-link"),
-  muteWarning: document.getElementById("mute-warning"),
 };
 
 // Player instance
@@ -30,19 +29,6 @@ let syncUpdateInterval = null;
 const serverUrl = `${location.protocol}//${location.host}`;
 elements.shareServerUrl.textContent = serverUrl;
 elements.shareServerUrl.href = serverUrl;
-
-/**
- * Detect if user is on iOS/iPhone
- */
-function isIOS() {
-  return /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-}
-
-// Show mute warning for iOS users
-if (isIOS()) {
-  elements.muteWarning.classList.remove("hidden");
-}
 
 /**
  * Initialize the Sendspin player (called after user interaction)

--- a/sendspin/serve/web/index.html
+++ b/sendspin/serve/web/index.html
@@ -23,16 +23,6 @@
         </button>
       </div>
 
-      <!-- iPhone mute warning (shown only on iOS) -->
-      <div id="mute-warning" class="card warning hidden">
-        <div class="warning-content">
-          <span class="warning-icon">⚠️</span>
-          <div class="warning-text">
-            <strong>iPhone users:</strong> Make sure your mute switch is off to hear audio
-          </div>
-        </div>
-      </div>
-
       <!-- Player controls (hidden until started) -->
       <div id="player-card" class="card player hidden">
         <div class="player-volume">

--- a/sendspin/serve/web/styles.css
+++ b/sendspin/serve/web/styles.css
@@ -66,34 +66,6 @@ header h1 {
   width: 100%;
 }
 
-/* Warning banner */
-.warning {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-}
-
-.warning-content {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.warning-icon {
-  font-size: 24px;
-  flex-shrink: 0;
-}
-
-.warning-text {
-  font-size: 14px;
-  line-height: 1.5;
-  flex: 1;
-}
-
-.warning-text strong {
-  font-weight: 600;
-}
-
 /* Buttons */
 .btn {
   padding: 12px 24px;


### PR DESCRIPTION
## Summary
- Remove the iOS mute switch warning banner from the embedded web player
- Remove the `isIOS()` detection function
- Remove associated CSS styles

The mute switch warning is no longer needed now that sendspin-js 1.0 properly handles iOS audio playback via #89.

## Test plan
- [x] Run `sendspin serve <audio-file>` and open on iOS device
- [x] Verify warning banner no longer appears
- [x] Verify audio playback works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)