### PR TITLE
Update cast link to use full server URL

### DIFF
--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -95,7 +95,7 @@ function disconnect() {
 
 // Set up Cast link with server URL
 elements.castLink.href = `https://sendspin.github.io/cast/?host=${encodeURIComponent(
-  location.hostname,
+  serverUrl,
 )}`;
 
 if (["localhost", "127.0.0.1"].includes(location.hostname)) {


### PR DESCRIPTION
The cast page now accepts full server URLs instead of just hostnames/IPs
(see Sendspin/cast#25). Updated the cast link to pass the complete serverUrl
(including protocol and port) instead of just location.hostname.