### PR TITLE
Systemd install: use settings-daemon.json and refactor/improve

### DIFF
--- a/scripts/systemd/install-systemd.sh
+++ b/scripts/systemd/install-systemd.sh
@@ -31,7 +31,7 @@ fi
 prompt_yn() {
     local question="$1"
     local default="${2:-yes}"
-    
+
     if [ "$INTERACTIVE" = true ]; then
         if [ "$default" = "no" ]; then
             read -p "$question [y/N] " -n1 -r REPLY </dev/tty; echo
@@ -67,7 +67,7 @@ prompt_input() {
 install_package() {
     local canonical_name="$1"
     local pkg_name="$canonical_name"  # default to canonical name
-    
+
     # Map canonical package names to distro-specific names
     case "$PKG_MGR:$canonical_name" in
         pacman:libportaudio2) pkg_name="portaudio" ;;
@@ -75,7 +75,7 @@ install_package() {
         dnf:libopenblas0|yum:libopenblas0) pkg_name="openblas" ;;
         # Additional mappings can be added here as needed
     esac
-    
+
     # Construct install command for the package manager
     local CMD=""
     case "$PKG_MGR" in
@@ -84,7 +84,7 @@ install_package() {
         apt-get) CMD="$PKG_MGR install -y $pkg_name" ;;
         *) CMD="$PKG_MGR install -y $pkg_name" ;;
     esac
-    
+
     if prompt_yn "Install now? ($CMD)"; then
         $CMD || { echo -e "${R}Failed${N}"; return 1; }
         return 0
@@ -111,7 +111,7 @@ if [[ -n "$SUDO_USER" && "$SUDO_USER" != "root" ]]; then
     echo -e "${D}You can run sendspin as a dedicated 'sendspin' user (recommended)"
     echo -e "or as your current user ($SUDO_USER).${N}"
     echo ""
-    
+
     if prompt_yn "Use dedicated 'sendspin' user?" "yes"; then
         DAEMON_USER="sendspin"
         DAEMON_HOME="/home/sendspin"
@@ -131,10 +131,10 @@ if [ "$USE_DEDICATED_USER" = true ] && ! id -u sendspin &>/dev/null; then
     echo -e "${D}Creating sendspin system user...${N}"
     useradd -r -m -d "$DAEMON_HOME" -s /bin/bash -c "Sendspin Daemon" sendspin || \
         { echo -e "${R}Failed to create user${N}"; exit 1; }
-    
+
     # Add to audio group for audio device access
     usermod -a -G audio sendspin 2>/dev/null || true
-    
+
     echo -e "${G}✓${N} Created sendspin system user"
 elif [ "$USE_DEDICATED_USER" = true ]; then
     echo -e "${D}User 'sendspin' already exists${N}"

--- a/scripts/systemd/uninstall-systemd.sh
+++ b/scripts/systemd/uninstall-systemd.sh
@@ -25,7 +25,7 @@ fi
 prompt_yn() {
     local question="$1"
     local default="${2:-yes}"
-    
+
     if [ "$INTERACTIVE" = true ]; then
         if [ "$default" = "no" ]; then
             read -p "$question [y/N] " -n1 -r REPLY </dev/tty; echo
@@ -114,7 +114,7 @@ if [ -n "$DAEMON_USER" ]; then
         echo -e "${D}Removing configuration...${N}"
         rm -rf "$CONFIG_DIR"
     fi
-    
+
     # Uninstall sendspin
     if sudo -u "$DAEMON_USER" bash -l -c "command -v uv" &>/dev/null; then
         echo -e "${D}Uninstalling sendspin from $DAEMON_USER...${N}"


### PR DESCRIPTION
Some significant shifts for the systemd install script:

* Update to use settings-daemon.json exclusively (systemd unit just runs `sendspin daemon`)
* Update to default to using a dedicated 'sendspin' user, which is proper for a nice daemon unit
* Install uv and sendspin under the sendspin user
* Offer a default client_id but also allow customization in the install
* Works for upgrades as well (checks if things are already done at each step and updates sendspin if installed)
* Also works for upgrades installed using the previous scripts, and defaults to previously configured values.
* Use DBUS environment to ensure that getting and using audio devices for the daemon user (whether sendspin or other user) works the same in the install as when running the daemon. Should resolve #77 (I was even able to reproduce, and with this change, can now see my preferred audio device both in the install and in the daemon logs, matching).
* Update uninstall as well to align with the install.

Should be pretty robust now.