### PR TITLE
Run Chromecast disconnect in executor to avoid blocking event loop

### DIFF
--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -239,7 +239,7 @@ async def run_server(config: ServeConfig) -> int:
     finally:
         with suppress(Exception):
             for cc_client in chromecast_clients:
-                disconnect_chromecast(cc_client)
+                await disconnect_chromecast(cc_client)
 
             await server.close()
 

--- a/sendspin/serve/chromecast.py
+++ b/sendspin/serve/chromecast.py
@@ -213,15 +213,20 @@ async def _send_sendspin_config(
     await loop.run_in_executor(None, send_message)
 
 
-def disconnect_chromecast(client: ChromecastClient) -> None:
+async def disconnect_chromecast(client: ChromecastClient) -> None:
     """Disconnect from a Chromecast device.
 
     Args:
         client: The ChromecastClient to disconnect
     """
-    try:
-        client.cast.quit_app()
-        client.cast.disconnect()
-        logger.info("Disconnected from Chromecast: %s", client.friendly_name)
-    except Exception:
-        logger.debug("Error disconnecting from Chromecast", exc_info=True)
+    loop = asyncio.get_running_loop()
+
+    def _disconnect() -> None:
+        try:
+            client.cast.quit_app()
+            client.cast.disconnect()
+        except Exception:
+            logger.debug("Error disconnecting from Chromecast", exc_info=True)
+
+    await loop.run_in_executor(None, _disconnect)
+    logger.info("Disconnected from Chromecast: %s", client.friendly_name)


### PR DESCRIPTION
The disconnect_chromecast function performs blocking I/O operations
(quit_app and disconnect from pychromecast) and was being called
directly from async code. This blocks the event loop.

Changes:
- Convert disconnect_chromecast to async function
- Wrap blocking disconnect calls in loop.run_in_executor()
- Update call site to await the disconnect operation

This follows the same pattern used for other blocking Chromecast
operations in the codebase (connect, launch, send_message).