### PR TITLE
Bump aiosendspin-mpris to 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
   "aiosendspin~=3.0",
-  "aiosendspin-mpris~=2.1",
+  "aiosendspin-mpris~=2.1.1",
   "av>=14.0.0",
   "numpy>=1.24.0",
   "pychromecast>=14.0.0",


### PR DESCRIPTION
This release patches mpris-api to fix https://github.com/Sendspin/sendspin-cli/issues/70

It will now log a simpler warning:
`WARNING:aiosendspin_mpris.mpris_service:MPRIS not available: DBus address error`
