### PR TITLE
Fix systemd protecting sendspin user's home dir and preventing settings save

### DIFF
--- a/scripts/systemd/install-systemd.sh
+++ b/scripts/systemd/install-systemd.sh
@@ -314,7 +314,6 @@ StandardError=journal
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=read-only
 SupplementaryGroups=audio
 
 [Install]


### PR DESCRIPTION
I was overzealous with the security and neglected to allow the systemd daemon to write to the daemon user's home, which is necessary to save settings in .config/sendspin. We'll allow it.

If users encounter this error or associated issues after installing previously, they can either re-run the script, or remove the ProtectHome line from the systemd unit file, and run `systemctl daemon-reload && systemctl restart sendspin`.