### PR TITLE
allow specifying source ffmpeg format

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Settings are stored in `~/.config/sendspin/`:
 | `use_mpris` | boolean | TUI/daemon | Enable MPRIS integration (default: true) |
 | `hook_start` | string | TUI/daemon | Command to run when audio stream starts |
 | `hook_stop` | string | TUI/daemon | Command to run when audio stream stops |
-| `source` | string | serve | Default audio source (file path or URL) |
+| `source` | string | serve | Default audio source (file path or URL, ffmpeg input) |
+| `source_format` | string | serve | ffmpeg container format for audio source |
 | `clients` | array | serve | Client URLs to connect to (`--client`) |
 
 Settings are automatically saved when changed through the TUI. You can also edit the JSON file directly while the client is not running.

--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -76,6 +76,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Audio source: local file path or URL (http/https)",
     )
     serve_parser.add_argument(
+        "--source-format",
+        default=None,
+        help="ffmpeg container format for source audio",
+    )
+    serve_parser.add_argument(
         "--demo",
         action="store_true",
         help="Use a demo audio stream (retro dance music)",
@@ -392,6 +397,7 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
 
     serve_config = ServeConfig(
         source=source,
+        source_format=args.source_format or settings.source_format,
         port=args.port,
         name=args.name,
         clients=args.clients or settings.clients,

--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -63,6 +63,7 @@ class ServeConfig:
     """Configuration for the serve command."""
 
     source: str
+    source_format: str | None = None
     port: int = 8928
     name: str = "Sendspin Server"
     clients: list[str] | None = None
@@ -220,7 +221,7 @@ async def run_server(config: ServeConfig) -> int:
 
             # Decode and stream audio
             try:
-                audio_source = await decode_audio(config.source)
+                audio_source = await decode_audio(config.source, source_format=config.source_format)
                 media_stream = MediaStream(
                     main_channel_source=audio_source.generator,
                     main_channel_format=audio_source.format,

--- a/sendspin/serve/source.py
+++ b/sendspin/serve/source.py
@@ -50,6 +50,7 @@ async def decode_audio(
     *,
     target_sample_rate: int = 48000,
     target_channels: int = 2,
+    source_format: str | None = None,
 ) -> AudioSource:
     """
     Decode an audio source (file path or URL) to PCM.
@@ -78,7 +79,7 @@ async def decode_audio(
                 if container is not None:
                     container.close()
 
-                container = av.open(source)
+                container = av.open(format=source_format, file=source)
                 resampler = av.AudioResampler(format="s16", layout=layout, rate=target_sample_rate)
                 for frame in container.decode(container.streams.audio[0]):
                     for resampled in resampler.resample(frame):

--- a/sendspin/settings.py
+++ b/sendspin/settings.py
@@ -201,6 +201,7 @@ class ServeSettings(BaseSettings):
     """Settings for serve mode."""
 
     source: str | None = None
+    source_format: str | None = None
     clients: list[str] | None = None
 
     def update(
@@ -210,6 +211,7 @@ class ServeSettings(BaseSettings):
         log_level: str | None = None,
         listen_port: int | None = None,
         source: str | None = None,
+        source_format: str | None = None,
         clients: list[str] | None = None,
     ) -> None:
         """Update settings fields. Only changed fields trigger a save."""
@@ -219,6 +221,7 @@ class ServeSettings(BaseSettings):
                 "log_level": log_level,
                 "listen_port": listen_port,
                 "source": source,
+                "source_format": source_format,
                 "clients": clients,
             }
         )
@@ -238,6 +241,7 @@ class ServeSettings(BaseSettings):
             self.log_level = data.get("log_level")
             self.listen_port = data.get("listen_port")
             self.source = data.get("source")
+            self.source_format = data.get("source_format")
             self.clients = data.get("clients")
             logger.info("Loaded settings from %s", self._settings_file)
         except (json.JSONDecodeError, OSError) as e:


### PR DESCRIPTION
A requested feature in music assistant is a music provider for [local audio input](https://github.com/orgs/music-assistant/discussions/1156). I figured why not also put that ability in to the sendspin serve cli for a stand alone way of doing it without music assistant. Because pyav is used to load the input source we can do that just by specifying the ffmpeg input source format along with the source.

Steps to get it running:

1. `pip install --no-binary av .` (necessary to use OS installed ffmpeg for alsa/pulse devices)
2. `sendspin serve --source-format pulse default` (or `sendspin serve --source-format alsa hw:0`)

Latency seems to be about 5 seconds on my machine but it is better than nothing!

You can even get it to stream from your phone's bluetooth paired to the computer with a few more steps:

1. pair the phone to the computer and select it as the media output device on your phone
2. create a virtual output device: `pactl load-module module-null-sink sink_name=sendspin`
3. use pavucontrol's playback tab to select the new sendspin output device as the playback "hardware" for your bluetooth stream (show all streams at bottom first)
4. `sendspin serve --source-format pulse sendspin.monitor`