### PR TITLE
Fix metadata not showing after connect or group switch

### DIFF
--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -587,17 +587,11 @@ class SendspinApp:
         assert self._ui is not None
         state = self._state
         ui = self._ui
-        # Only clear metadata when actually switching to a different group
-        group_changed = payload.group_id is not None and payload.group_id != state.group_id
-        if group_changed:
+        # Track group ID changes for logging. Metadata clearing is not needed here
+        # because the server always sends a metadata update (snapshot or cleared)
+        # before the group update message when groups change.
+        if payload.group_id is not None and payload.group_id != state.group_id:
             state.group_id = payload.group_id
-            state.title = None
-            state.artist = None
-            state.album = None
-            state.track_progress = None
-            state.track_duration = None
-            ui.set_metadata(title=None, artist=None, album=None)
-            ui.clear_progress()
             ui.add_event(f"Group ID: {payload.group_id}")
 
         if payload.group_name:


### PR DESCRIPTION
## Summary

- Remove metadata clearing from `_handle_group_update` which raced against server-sent metadata updates, causing track info to disappear on connect and group switch

## Root Cause

The `_handle_group_update` handler cleared all metadata (title, artist, album, progress) whenever `group_id` changed. This included the initial connection where `state.group_id` transitions from `None` to the actual group ID, and any group switch.

The problem is that the aiosendspin server always sends metadata **before** the group update in every group transition path, so the clearing was wiping freshly received metadata:

### Server-side message ordering (aiosendspin)

**Initial connection:**
1. `MetadataV1Role.on_connect()` → `_subscribe_to_group_role()` → `MetadataGroupRole.on_member_join()` → `_send_state_to_role()` → **metadata sent**
2. `Group.on_client_connected()` → **group update sent**

**Group switch via `add_client()`:**
1. `client._set_group()` → `role.on_group_changed()` → re-subscribes to new `MetadataGroupRole` → `on_member_join()` → `_send_state_to_role()` → **metadata sent**
2. `add_client()` sends `GroupUpdateServerMessage` → **group update sent**

**Group switch via `remove_client()`:**
1. `SendspinGroup.__init__()` → `client._set_group()` → same re-subscribe flow → **metadata sent**
2. `on_client_connected()` → **group update sent**

In all paths, the server sends either a full metadata snapshot (via `Metadata.snapshot_update()`) or a cleared update with all fields set to `None` (via `Metadata.cleared_update()`). The existing `_handle_metadata_update` callback already handles both correctly, making the clearing in `_handle_group_update` redundant and harmful.

### What happened on the client

1. Metadata update arrives → `_handle_metadata_update` stores title/artist/album and updates UI
2. Group update arrives → `_handle_group_update` sees `group_id` changed → wipes the metadata that was just set
3. No further metadata update comes until the next track change → metadata stays blank

## Test plan

- [ ] Connect to a server with an active track playing — metadata should display immediately
- [ ] Switch groups (`g` key) to a group with active playback — metadata should display for the new group
- [ ] Switch to an empty group — metadata should clear (handled by the server's `cleared_update`)
- [ ] Reconnect after disconnect — metadata should restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)