### PR TITLE
Prioritize bit depth over sample rate in supported format ordering

### DIFF
--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -128,8 +128,8 @@ def detect_supported_audio_formats(
     supported: list[SupportedAudioFormat] = []
 
     # Add FLAC formats first (preferred)
-    for rate in supported_rates:
-        for depth in supported_depths:
+    for depth in supported_depths:
+        for rate in supported_rates:
             for ch in supported_channels:
                 supported.append(
                     SupportedAudioFormat(
@@ -138,8 +138,8 @@ def detect_supported_audio_formats(
                 )
 
     # Add PCM formats as fallback
-    for rate in supported_rates:
-        for depth in supported_depths:
+    for depth in supported_depths:
+        for rate in supported_rates:
             for ch in supported_channels:
                 supported.append(
                     SupportedAudioFormat(


### PR DESCRIPTION
## Summary
- Reorder supported format loops so bit depth (24 > 16) is prioritized over sample rate, with mono always listed after stereo
- Overall priority: FLAC > PCM, 24-bit > 16-bit, sample rate, stereo > mono

## Test plan
- [x] Verify format list ordering with `logger.info` output on a connected device

🤖 Generated with [Claude Code](https://claude.com/claude-code)