### PR TITLE
Remove limitations and known issues section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,12 +264,6 @@ sendspin --log-level DEBUG
 
 This provides detailed information about time synchronization. The output can be helpful when reporting issues.
 
-## Limitations & Known Issues
-
-This player is highly experimental and has several known limitations:
-
-- **Format Support**: Currently fixed to uncompressed 44.1kHz 16-bit stereo PCM
-
 ## Install as Daemon (systemd, Linux)
 
 For headless devices like Raspberry Pi, you can install `sendspin daemon` as a systemd service that starts automatically on boot.


### PR DESCRIPTION
## Summary
Removed the "Limitations & Known Issues" section from the README documentation.

## Changes
- Deleted the "Limitations & Known Issues" section that documented the player's experimental status and format support constraints (uncompressed 44.1kHz 16-bit stereo PCM)

## Rationale
This section appears to have been removed as it may no longer accurately reflect the current state of the project, or the limitations have been addressed in recent updates.

https://claude.ai/code/session_013XDaJ6tmMvnLPDAyKWYVhF