### PR TITLE
Consolidate volume change flows through AudioStreamHandler

### DIFF
--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -8,10 +8,11 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from aiosendspin.models.core import StreamStartMessage
-from aiosendspin.models.types import AudioCodec, Roles
+from aiosendspin.models.types import AudioCodec, PlayerStateType, Roles
 
 from sendspin.audio import AudioDevice, AudioPlayer
 from sendspin.decoder import FlacDecoder
+from sendspin.utils import create_task
 
 if TYPE_CHECKING:
     from aiosendspin.client import AudioFormat, SendspinClient
@@ -35,6 +36,7 @@ class AudioStreamHandler:
         muted: bool = False,
         on_event: Callable[[str], None] | None = None,
         on_format_change: Callable[[str | None, int, int, int], None] | None = None,
+        on_volume_change: Callable[[int, bool], None] | None = None,
     ) -> None:
         """Initialize the audio stream handler.
 
@@ -44,12 +46,14 @@ class AudioStreamHandler:
             muted: Initial muted state.
             on_event: Callback for stream lifecycle events ("start" or "stop").
             on_format_change: Callback for format changes (codec, sample_rate, bit_depth, channels).
+            on_volume_change: Callback for external volume changes.
         """
         self._audio_device = audio_device
         self._volume = volume
         self._muted = muted
         self._on_event = on_event
         self._on_format_change = on_format_change
+        self._on_volume_change = on_volume_change
         self._client: SendspinClient | None = None
         self.audio_player: AudioPlayer | None = None
         self._current_format: AudioFormat | None = None
@@ -59,7 +63,8 @@ class AudioStreamHandler:
     def set_volume(self, volume: int, *, muted: bool) -> None:
         """Set the volume and muted state.
 
-        Updates the cached values and applies to the audio player if active.
+        Updates the cached values, applies to the audio player if active,
+        notifies the server, and fires the on_volume_change callback.
 
         Args:
             volume: Volume level (0-100).
@@ -69,6 +74,20 @@ class AudioStreamHandler:
         self._muted = muted
         if self.audio_player is not None:
             self.audio_player.set_volume(volume, muted=muted)
+        self.send_player_volume()
+        if self._on_volume_change is not None:
+            self._on_volume_change(volume, muted)
+
+    def send_player_volume(self) -> None:
+        """Send current player volume/mute state to the server."""
+        if self._client is not None and self._client.connected:
+            create_task(
+                self._client.send_player_state(
+                    state=PlayerStateType.SYNCHRONIZED,
+                    volume=self._volume,
+                    muted=self._muted,
+                )
+            )
 
     def attach_client(self, client: SendspinClient) -> list[Callable[[], None]]:
         """Attach to a SendspinClient and register listeners.

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -20,7 +20,6 @@ from aiosendspin_mpris import MPRIS_AVAILABLE, SendspinMpris
 from aiosendspin.models.types import (
     GoodbyeReason,
     PlayerCommand,
-    PlayerStateType,
     Roles,
 )
 
@@ -127,6 +126,7 @@ class SendspinDaemon:
             muted=self._settings.player_muted,
             on_event=self._on_stream_event,
             on_format_change=self._handle_format_change,
+            on_volume_change=self._on_volume_change,
         )
 
         try:
@@ -151,6 +151,12 @@ class SendspinDaemon:
             logger.info("Daemon stopped")
 
         return 0
+
+    def _on_volume_change(self, volume: int, muted: bool) -> None:
+        """Handle volume changes from any source (server command, external, etc.)."""
+        assert self._settings is not None
+
+        self._settings.update(player_volume=volume, player_muted=muted)
 
     async def _run_client_initiated(self, static_delay_ms: float) -> None:
         """Run in client-initiated mode, connecting to a specific URL."""
@@ -230,11 +236,7 @@ class SendspinDaemon:
 
             try:
                 await client.attach_websocket(ws)
-                await self._client.send_player_state(
-                    state=PlayerStateType.SYNCHRONIZED,
-                    volume=self._settings.player_volume,
-                    muted=self._settings.player_muted,
-                )
+                self._audio_handler.send_player_volume()
             except TimeoutError:
                 logger.warning("Handshake with server timed out")
                 await self._stop_mpris_and_audio()
@@ -274,11 +276,7 @@ class SendspinDaemon:
         while True:
             try:
                 await self._client.connect(url)
-                await self._client.send_player_state(
-                    state=PlayerStateType.SYNCHRONIZED,
-                    volume=self._settings.player_volume,
-                    muted=self._settings.player_muted,
-                )
+                self._audio_handler.send_player_volume()
                 error_backoff = 1.0
 
                 # Wait for disconnect
@@ -308,34 +306,19 @@ class SendspinDaemon:
                 break
 
     def _handle_server_command(self, payload: ServerCommandPayload) -> None:
-        """Handle server commands for player volume/mute control and save to settings."""
-        if payload.player is None or self._settings is None or self._client is None:
+        """Handle server commands for player volume/mute control."""
+        if payload.player is None or self._settings is None:
             return
 
         assert self._audio_handler is not None
         player_cmd = payload.player
 
         if player_cmd.command == PlayerCommand.VOLUME and player_cmd.volume is not None:
-            self._settings.update(player_volume=player_cmd.volume)
-            self._audio_handler.set_volume(
-                self._settings.player_volume, muted=self._settings.player_muted
-            )
+            self._audio_handler.set_volume(player_cmd.volume, muted=self._settings.player_muted)
             logger.info("Server set player volume: %d%%", player_cmd.volume)
         elif player_cmd.command == PlayerCommand.MUTE and player_cmd.mute is not None:
-            self._settings.update(player_muted=player_cmd.mute)
-            self._audio_handler.set_volume(
-                self._settings.player_volume, muted=self._settings.player_muted
-            )
+            self._audio_handler.set_volume(self._settings.player_volume, muted=player_cmd.mute)
             logger.info("Server %s player", "muted" if player_cmd.mute else "unmuted")
-
-        # Send state update back to server per spec
-        create_task(
-            self._client.send_player_state(
-                state=PlayerStateType.SYNCHRONIZED,
-                volume=self._settings.player_volume,
-                muted=self._settings.player_muted,
-            )
-        )
 
     def _handle_format_change(
         self, codec: str | None, sample_rate: int, bit_depth: int, channels: int

--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -30,7 +30,6 @@ from aiosendspin.models.types import (
     MediaCommand,
     PlaybackStateType,
     PlayerCommand,
-    PlayerStateType,
     Roles,
     UndefinedField,
 )
@@ -304,6 +303,7 @@ class SendspinApp:
                 muted=self._settings.player_muted,
                 on_event=self._on_stream_event,
                 on_format_change=self._handle_format_change,
+                on_volume_change=self._on_volume_change,
             )
 
             await self._discovery.start()
@@ -390,13 +390,15 @@ class SendspinApp:
 
         return 0
 
-    async def _send_player_volume(self) -> None:
-        """Send current player volume/mute state to the server."""
-        await self._client.send_player_state(
-            state=PlayerStateType.SYNCHRONIZED,
-            volume=self._state.player_volume,
-            muted=self._state.player_muted,
-        )
+    def _on_volume_change(self, volume: int, muted: bool) -> None:
+        """Handle volume changes from any source (server command, keyboard, external)."""
+        assert self._settings is not None
+        assert self._ui is not None
+
+        self._state.player_volume = volume
+        self._state.player_muted = muted
+        self._settings.update(player_volume=volume, player_muted=muted)
+        self._ui.set_player_volume(volume, muted=muted)
 
     async def _connect_cancellable(self, url: str) -> None:
         """Connect to server. Can be cancelled by _cancel_connect().
@@ -463,7 +465,7 @@ class SendspinApp:
         while True:
             try:
                 if skip_connect:
-                    await self._send_player_volume()
+                    self._audio_handler.send_player_volume()
                     skip_connect = False
                 else:
                     try:
@@ -474,7 +476,7 @@ class SendspinApp:
                         continue
                     ui.add_event(f"Connected to {url}")
                     ui.set_connected(url)
-                    await self._send_player_volume()
+                    self._audio_handler.send_player_volume()
                     manager.reset_backoff()
                     manager.set_last_attempted_url(url)
                     if self._settings:
@@ -639,34 +641,18 @@ class SendspinApp:
         if payload.player is None:
             return
 
-        assert self._settings is not None
         assert self._audio_handler is not None
         assert self._ui is not None
-        state = self._state
-        ui = self._ui
         player_cmd: PlayerCommandPayload = payload.player
 
         if player_cmd.command == PlayerCommand.VOLUME and player_cmd.volume is not None:
-            state.player_volume = player_cmd.volume
-            self._settings.update(player_volume=player_cmd.volume)
-            self._audio_handler.set_volume(state.player_volume, muted=state.player_muted)
-            ui.set_player_volume(state.player_volume, muted=state.player_muted)
-            ui.add_event(f"Server set player volume: {player_cmd.volume}%")
+            self._audio_handler.set_volume(player_cmd.volume, muted=self._state.player_muted)
+            self._ui.add_event(f"Server set player volume: {player_cmd.volume}%")
         elif player_cmd.command == PlayerCommand.MUTE and player_cmd.mute is not None:
-            state.player_muted = player_cmd.mute
-            self._settings.update(player_muted=player_cmd.mute)
-            self._audio_handler.set_volume(state.player_volume, muted=state.player_muted)
-            ui.set_player_volume(state.player_volume, muted=state.player_muted)
-            ui.add_event("Server muted player" if player_cmd.mute else "Server unmuted player")
-
-        # Send state update back to server per spec
-        create_task(
-            self._client.send_player_state(
-                state=PlayerStateType.SYNCHRONIZED,
-                volume=state.player_volume,
-                muted=state.player_muted,
+            self._audio_handler.set_volume(self._state.player_volume, muted=player_cmd.mute)
+            self._ui.add_event(
+                "Server muted player" if player_cmd.mute else "Server unmuted player"
             )
-        )
 
     def _handle_format_change(
         self, codec: str | None, sample_rate: int, bit_depth: int, channels: int

--- a/sendspin/tui/keyboard.py
+++ b/sendspin/tui/keyboard.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 import readchar
-from aiosendspin.models.types import MediaCommand, PlaybackStateType, PlayerStateType
+from aiosendspin.models.types import MediaCommand, PlaybackStateType
 
 if TYPE_CHECKING:
     from aiosendspin.client import SendspinClient
@@ -53,32 +53,17 @@ class CommandHandler:
         else:
             await self.send_media_command(MediaCommand.PLAY)
 
-    async def change_player_volume(self, delta: int) -> None:
+    def change_player_volume(self, delta: int) -> None:
         """Adjust player (local) volume by delta."""
         target = max(0, min(100, self._state.player_volume + delta))
-        self._state.player_volume = target
-        self._settings.update(player_volume=target)
-        self._audio_handler.set_volume(self._state.player_volume, muted=self._state.player_muted)
-        self._ui.set_player_volume(self._state.player_volume, muted=self._state.player_muted)
-        await self._client.send_player_state(
-            state=PlayerStateType.SYNCHRONIZED,
-            volume=self._state.player_volume,
-            muted=self._state.player_muted,
-        )
+        self._audio_handler.set_volume(target, muted=self._state.player_muted)
         self._ui.add_event(f"Player volume: {target}%")
 
-    async def toggle_player_mute(self) -> None:
+    def toggle_player_mute(self) -> None:
         """Toggle player (local) mute state."""
-        self._state.player_muted = not self._state.player_muted
-        self._settings.update(player_muted=self._state.player_muted)
-        self._audio_handler.set_volume(self._state.player_volume, muted=self._state.player_muted)
-        self._ui.set_player_volume(self._state.player_volume, muted=self._state.player_muted)
-        await self._client.send_player_state(
-            state=PlayerStateType.SYNCHRONIZED,
-            volume=self._state.player_volume,
-            muted=self._state.player_muted,
-        )
-        self._ui.add_event("Player muted" if self._state.player_muted else "Player unmuted")
+        muted = not self._state.player_muted
+        self._audio_handler.set_volume(self._state.player_volume, muted=muted)
+        self._ui.add_event("Player muted" if muted else "Player unmuted")
 
     async def adjust_delay(self, delta: float) -> None:
         """Adjust static delay by delta milliseconds."""
@@ -115,9 +100,9 @@ async def keyboard_loop(
     """
     handler = CommandHandler(client, state, audio_handler, ui, settings)
 
-    # Key dispatch table: key -> (highlight_name | None, async action)
-    # For keys that need case-insensitive matching, use lowercase
-    shortcuts: dict[str, tuple[str | None, Callable[[], Awaitable[None]]]] = {
+    # Key dispatch table: key -> (highlight_name | None, action)
+    # Actions can be sync or async. For keys that need case-insensitive matching, use lowercase.
+    shortcuts: dict[str, tuple[str | None, Callable[[], Awaitable[None] | None]]] = {
         # Letter keys
         " ": ("space", handler.toggle_play_pause),
         "m": ("mute", handler.toggle_player_mute),
@@ -190,7 +175,9 @@ async def keyboard_loop(
             highlight_name, action_handler = action
             if highlight_name and ui:
                 ui.highlight_shortcut(highlight_name)
-            await action_handler()
+            result = action_handler()
+            if result is not None:
+                await result
             continue
 
         # Ignore unhandled escape sequences


### PR DESCRIPTION
## Summary
- Make `AudioStreamHandler.set_volume()` the single entry point for all volume changes (keyboard, server commands, external)
- Add `send_player_volume()` method to `AudioStreamHandler` for on-connect server notification
- Add `on_volume_change` callback for app-local concerns (state, settings, UI persistence)
- Remove duplicated volume propagation logic from keyboard handler, TUI app, and daemon

## Test plan
- [x] Keyboard volume up/down/mute still works in TUI mode
- [x] Server-initiated volume/mute commands are applied and echoed back
- [x] Volume state persists across restarts (settings file updated)
- [x] Volume is reported to server on connect/reconnect
- [x] Daemon mode volume commands from server still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)