### PR TITLE
Bump aiosendspin dependency to ~=4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "aiosendspin~=4.0",
+  "aiosendspin~=4.2",
   "aiosendspin-mpris~=2.1.1",
   "av>=14.0.0",
   "numpy>=1.24.0",


### PR DESCRIPTION
## Summary
- Bump `aiosendspin` minimum version from `~=4.0` to `~=4.2`

https://github.com/Sendspin/aiosendspin/releases/tag/4.2.0
https://github.com/Sendspin/aiosendspin/releases/tag/4.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)