### PR TITLE
Fix: pass initial volume/muted from settings to SendspinClient

### DIFF
--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -236,7 +236,6 @@ class SendspinDaemon:
 
             try:
                 await client.attach_websocket(ws)
-                self._audio_handler.send_player_volume()
             except TimeoutError:
                 logger.warning("Handshake with server timed out")
                 await self._stop_mpris_and_audio()
@@ -276,7 +275,6 @@ class SendspinDaemon:
         while True:
             try:
                 await self._client.connect(url)
-                self._audio_handler.send_player_volume()
                 error_backoff = 1.0
 
                 # Wait for disconnect

--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -467,7 +467,6 @@ class SendspinApp:
         while True:
             try:
                 if skip_connect:
-                    self._audio_handler.send_player_volume()
                     skip_connect = False
                 else:
                     try:
@@ -478,7 +477,6 @@ class SendspinApp:
                         continue
                     ui.add_event(f"Connected to {url}")
                     ui.set_connected(url)
-                    self._audio_handler.send_player_volume()
                     manager.reset_backoff()
                     manager.set_last_attempted_url(url)
                     if self._settings:


### PR DESCRIPTION
## Summary
- Pass `initial_volume` and `initial_muted` from settings when creating `SendspinClient` in both the daemon and TUI app
- Previously, the client always told the server its volume was 100 (the default) during the handshake, then immediately corrected it via `send_player_volume()`, causing an unnecessary extra message on every connect
- The daemon reads volume from `self._settings` (with fallback to defaults), and the TUI reads from `args.settings` which is available at construction time

## Test plan
- [ ] Start daemon with a non-default volume in settings (e.g. `player_volume: 50`), connect to a server, and verify only one player/state message is sent with volume=50 (not an initial volume=100 followed by volume=50)
- [ ] Start TUI app with a non-default volume in settings, connect to a server, and verify the same correct behavior
- [ ] Verify volume changes during a session still work correctly after reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)