### PR TITLE
Pass client_name to ClientListener and migrate PlayerStateType

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ The daemon runs in the background and logs status messages to stdout. It accepts
 sendspin daemon --name "Kitchen" --audio-device 2
 ```
 
+In daemon mode without `--url`, the client listens for incoming server connections and advertises itself via mDNS. The `--name` option (or `name` setting) is used as the friendly name in the mDNS advertisement, making it easy for servers to identify this client on the network.
+
 ### Hooks
 
 You can run external commands when audio streams start or stop. This is useful for controlling amplifiers, lighting, or other home automation:

--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from aiosendspin.models.core import StreamStartMessage
-from aiosendspin.models.types import AudioCodec, PlayerStateType, Roles
+from aiosendspin.models.types import AudioCodec, ClientStateType, Roles
 
 from sendspin.audio import AudioDevice, AudioPlayer
 from sendspin.decoder import FlacDecoder
@@ -93,7 +93,7 @@ class AudioStreamHandler:
         if self._client is not None and self._client.connected:
             create_task(
                 self._client.send_player_state(
-                    state=PlayerStateType.SYNCHRONIZED,
+                    state=ClientStateType.SYNCHRONIZED,
                     volume=self._volume,
                     muted=self._muted,
                 )

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -186,6 +186,7 @@ class SendspinDaemon:
             client_id=self._args.client_id,
             on_connection=self._handle_server_connection,
             port=self._args.listen_port,
+            client_name=self._args.client_name,
         )
         await self._listener.start()
 


### PR DESCRIPTION
## Summary

- Pass `client_name` to `ClientListener` in daemon mode so the friendly name is advertised via mDNS for server-initiated connections
- Migrate deprecated `PlayerStateType` alias to `ClientStateType` in `audio_connector.py`
- Document mDNS name behavior in README daemon mode section

## Test plan

- [ ] Run `sendspin daemon --name "Test"` without `--url` and verify the mDNS advertisement includes the friendly name
- [ ] Verify `mypy`, `ruff check`, and `ruff format` all pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)