### PR TITLE
Fix unnecessary reconnect when selecting the current server

### DIFF
--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -589,7 +589,7 @@ class SendspinApp:
 
         self._ui.hide_server_selector()
         # Skip reconnection if already connected to this server
-        if server == self._state.selected_server:
+        if self._state.selected_server and server.url == self._state.selected_server.url:
             return
 
         self._connection_manager.set_pending_server(server)


### PR DESCRIPTION
## Summary
- Compare servers by URL instead of full dataclass equality when the user selects a server from the TUI list
- Prevents an unnecessary disconnect/reconnect cycle when selecting the already-connected server
- The previous `==` check could fail when the `name` field differed (e.g. `"Last connected"` from settings-based startup vs the actual mDNS name)

## Test plan
- [ ] Start the TUI and let it auto-connect to a server
- [ ] Open the server selector (`s`), pick the current server, and verify it does **not** reconnect
- [ ] Pick a different server and verify it **does** reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)