### PR TITLE
Systemd Install: fix Pipewire/PulseAudio environments; refactor config file handling

### DIFF
--- a/scripts/systemd/install-systemd.sh
+++ b/scripts/systemd/install-systemd.sh
@@ -197,6 +197,7 @@ echo -e "\n${C}Installing Sendspin...${N}"
 if sudo -u "$DAEMON_USER" bash -l -c "uv tool list" 2>/dev/null | grep -q "^sendspin "; then
     echo -e "${D}Sendspin already installed, upgrading...${N}"
     sudo -u "$DAEMON_USER" bash -l -c "uv tool upgrade sendspin" || { echo -e "${R}Failed${N}"; exit 1; }
+    echo -e "  ${C}Release notes:${N} https://github.com/Sendspin/sendspin-cli/releases"
 else
     sudo -u "$DAEMON_USER" bash -l -c "uv tool install sendspin" || { echo -e "${R}Failed${N}"; exit 1; }
 fi


### PR DESCRIPTION
* Enable linger for the DAEMON_USER (sendspin) so Pipewire and PulseAudio start even without a login session
* Add environment variable for XDG_RUNTIME_DIR so Pipewire and PulseAudio sockets are accessible
* Improve install script ease for upgrades by loading any existing config values from an existing config file, if one exists

h/t @pdsccode via #141