### PR TITLE
feat(daemon): log MA group/update events to stdout

### DIFF
--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -13,6 +13,7 @@ from aiosendspin.client import ClientListener, SendspinClient
 from aiosendspin.models.core import (
     ClientGoodbyeMessage,
     ClientGoodbyePayload,
+    GroupUpdateServerPayload,
     ServerCommandPayload,
 )
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
@@ -176,6 +177,7 @@ class SendspinDaemon:
         self._audio_handler.attach_client(self._client)
         self._server_url = self._args.url
         self._client.add_server_command_listener(self._handle_server_command)
+        self._client.add_group_update_listener(self._handle_group_update)
         await self._connection_loop(self._args.url)
 
     async def _run_server_initiated(self, static_delay_ms: float) -> None:
@@ -238,6 +240,7 @@ class SendspinDaemon:
             self._client = client
             self._audio_handler.attach_client(client)
             client.add_server_command_listener(self._handle_server_command)
+            client.add_group_update_listener(self._handle_group_update)
             if MPRIS_AVAILABLE and self._args.use_mpris:
                 self._mpris = SendspinMpris(client)
                 self._mpris.start()
@@ -325,6 +328,12 @@ class SendspinDaemon:
         elif player_cmd.command == PlayerCommand.MUTE and player_cmd.mute is not None:
             self._audio_handler.set_volume(self._settings.player_volume, muted=player_cmd.mute)
             logger.info("Server %s player", "muted" if player_cmd.mute else "unmuted")
+
+    def _handle_group_update(self, payload: GroupUpdateServerPayload) -> None:
+        """Log group membership changes so integrations can track group state."""
+        if payload.group_id is not None:
+            logger.info("Group ID: %s", payload.group_id)
+        logger.info("Group name: %s", payload.group_name or "")
 
     def _handle_format_change(
         self, codec: str | None, sample_rate: int, bit_depth: int, channels: int


### PR DESCRIPTION
## Summary

Adds `GroupUpdateServerPayload` handling in daemon mode so that external integrations can track player group membership by parsing the daemon's stdout.

## Motivation

The `tui/app.py` already uses `add_group_update_listener()`, but `daemon.py` had no equivalent. Integrations that wrap the daemon process (e.g. [sendspin-bt-bridge](https://github.com/trudenboy/sendspin-bt-bridge)) have no way to know when the player joins/leaves a group without this.

## Changes

- Import `GroupUpdateServerPayload` in `daemon.py`
- Add `_handle_group_update()` method that logs:
  - `Group ID: <uuid>` (only when `group_id` is not None)
  - `Group name: <name>` (empty string when leaving a group)
- Register the listener in both connection paths:
  - `_run_client_initiated()` — URL / client-initiated mode
  - `_handle_server_connection()` — mDNS / server-initiated mode

The approach mirrors the existing `_handle_server_command()` pattern and uses the public `SendspinClient.add_group_update_listener()` API.