### PR TITLE
Prefer 16-bit formats when software volume is active

### DIFF
--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -97,6 +97,8 @@ def _check_format(device: int | None, rate: int, channels: int, dtype: str) -> b
 
 def detect_supported_audio_formats(
     device: int | None = None,
+    *,
+    prefer_16bit: bool = False,
 ) -> list[SupportedAudioFormat]:
     """Detect supported audio formats by testing dimensions independently.
 
@@ -110,12 +112,15 @@ def detect_supported_audio_formats(
 
     Args:
         device: Audio device ID. None for default device.
+        prefer_16bit: Whether to advertise 16-bit formats ahead of 24-bit ones.
+            This is useful when software volume is active, since 24-bit scaling
+            is more expensive in the playback pipeline.
 
     Returns:
         List of supported audio formats, with FLAC formats first (preferred).
     """
     sample_rates = [48000, 44100, 96000, 192000]
-    bit_depths = [24, 16]
+    bit_depths = [16, 24] if prefer_16bit else [24, 16]
     channel_counts = [2, 1]
 
     # Test each dimension independently

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -77,7 +77,10 @@ class SendspinDaemon:
         if MPRIS_AVAILABLE and self._args.use_mpris:
             client_roles.extend([Roles.METADATA, Roles.CONTROLLER])
 
-        supported_formats = detect_supported_audio_formats(self._args.audio_device.index)
+        supported_formats = detect_supported_audio_formats(
+            self._args.audio_device.index,
+            prefer_16bit=not self._args.use_hardware_volume,
+        )
         if self._args.preferred_format is not None:
             supported_formats = [f for f in supported_formats if f != self._args.preferred_format]
             supported_formats.insert(0, self._args.preferred_format)

--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -287,7 +287,10 @@ class SendspinApp:
             self._state.player_muted = self._audio_handler.muted
 
             # Detect supported audio formats for the output device
-            supported_formats = detect_supported_audio_formats(args.audio_device.index)
+            supported_formats = detect_supported_audio_formats(
+                args.audio_device.index,
+                prefer_16bit=not args.use_hardware_volume,
+            )
             if args.preferred_format is not None:
                 supported_formats = [f for f in supported_formats if f != args.preferred_format]
                 supported_formats.insert(0, args.preferred_format)

--- a/tests/test_audio_format_preferences.py
+++ b/tests/test_audio_format_preferences.py
@@ -1,0 +1,35 @@
+"""Tests for supported audio format preference ordering."""
+
+from __future__ import annotations
+
+from aiosendspin.models.types import AudioCodec
+
+from sendspin.audio import detect_supported_audio_formats
+
+
+def test_detect_supported_audio_formats_prefers_24bit_by_default(monkeypatch) -> None:
+    """Default ordering should keep 24-bit formats first."""
+    monkeypatch.setattr("sendspin.audio._check_format", lambda *_args: True)
+
+    formats = detect_supported_audio_formats()
+
+    flac_formats = [fmt for fmt in formats if fmt.codec == AudioCodec.FLAC]
+    pcm_formats = [fmt for fmt in formats if fmt.codec == AudioCodec.PCM]
+
+    assert flac_formats[0].bit_depth == 24
+    assert pcm_formats[0].bit_depth == 24
+
+
+def test_detect_supported_audio_formats_prefers_16bit_for_software_volume(
+    monkeypatch,
+) -> None:
+    """Software-volume mode should advertise 16-bit formats first."""
+    monkeypatch.setattr("sendspin.audio._check_format", lambda *_args: True)
+
+    formats = detect_supported_audio_formats(prefer_16bit=True)
+
+    flac_formats = [fmt for fmt in formats if fmt.codec == AudioCodec.FLAC]
+    pcm_formats = [fmt for fmt in formats if fmt.codec == AudioCodec.PCM]
+
+    assert flac_formats[0].bit_depth == 16
+    assert pcm_formats[0].bit_depth == 16


### PR DESCRIPTION
## Summary
- add a  option to supported format detection
- advertise 16-bit formats ahead of 24-bit when hardware volume is disabled
- add a regression test covering the default and software-volume orderings

## Testing
- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/paulus/dev/mass/sendspin-cli
configfile: pyproject.toml
collected 2 items

tests/test_audio_format_preferences.py ..                                [100%]

============================== 2 passed in 0.65s ===============================
- 
