### PR TITLE
Refine top-level CLI app help

### DIFF
--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -143,6 +143,7 @@ def _add_player_runtime_options(
         "--hardware-volume",
         default=default,
         type=arg_str_to_bool,
+        metavar="{true,false}",
         help="Enable or disable hardware/system volume control (daemon: on, TUI: off)",
     )
     target.add_argument(
@@ -343,6 +344,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--hardware-volume",
         default=None,
         type=arg_str_to_bool,
+        metavar="{true,false}",
         help="Enable or disable hardware/system volume control (daemon: on, TUI: off)",
     )
     daemon_parser.add_argument(


### PR DESCRIPTION
## Summary
- reorganize the top-level CLI help into actions, apps, and player options
- add an explicit `player` app alias while keeping plain `sendspin` as the default behavior
- hide deprecated `--headless` from help output while continuing to accept it

## Verification
- `uv run ruff check sendspin/cli.py`
- `python -m sendspin.cli --help`
- `python -m sendspin.cli --version`
- `python -m sendspin.cli --url ws://example.invalid/sendspin player --version`

## Notes
- `pytest -q` did not discover any tests in this checkout, so verification for this change is manual plus linting.
