### PR TITLE
Bump embedded sendspin-js to 2.0.3

### DIFF
--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -129,7 +129,7 @@ elements.volumeSlider.addEventListener("input", () => {
 });
 
 const sdkImport = import(
-  "https://unpkg.com/@sendspin/sendspin-js@2.0.2/dist/index.js"
+  "https://unpkg.com/@sendspin/sendspin-js@2.0.3/dist/index.js"
 );
 
 // QR Code generation (using qrcode-generator loaded via script tag)


### PR DESCRIPTION
## Summary
- update the embedded web player to load `@sendspin/sendspin-js@2.0.3` from unpkg
- keep the change scoped to the one CDN import used by `sendspin serve`

## Verification
- confirmed `@sendspin/sendspin-js@2.0.3` is published on unpkg
- confirmed `dist/index.js` resolves for version `2.0.3`