### PR TITLE
Bump cibuildwheel to v3.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,13 @@ jobs:
         with:
           platforms: arm64,arm
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.4.0
+        with:
+          extras: uv
         env:
           CIBW_ENVIRONMENT: "SENDSPIN_REQUIRE_C_EXT=1"
           CIBW_BUILD: cp312-* cp313-*
+          CIBW_BUILD_FRONTEND: "uv"
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_SKIP: "*-musllinux_*"
       - uses: actions/upload-artifact@v5


### PR DESCRIPTION
## Summary
- bump `pypa/cibuildwheel` from `v2.23.3` to `v3.4.0`
- enable `uv` for the wheel build via `extras: uv`
- set `CIBW_BUILD_FRONTEND` to `uv`

## Why
The recent release failure on macOS was caused before the package build started, when `cibuildwheel` hit an HTTP 429 while downloading `virtualenv.pyz`. This updates the wheel build to `cibuildwheel` 3.4.0 and uses the new `uv` build frontend support.

## Verification
- workflow YAML parses successfully locally