### PR TITLE
Explicitly set the package name sendspin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ test = [
   "ruff==0.14.5",
 ]
 
+[tool.setuptools.packages.find]
+include = ["sendspin*"]
+
 [tool.setuptools.package-data]
 "sendspin.serve" = ["web/*"]
 


### PR DESCRIPTION
Should hopefully fix the CI build issue by setting the package name to search for ``sendspin*``