### PR TITLE
Make Chromecast support optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ uvx sendspin serve https://retro.dancewave.online/retrodance.mp3
 uv tool install sendspin
 ```
 
+Support for Chromecast devices requires installation of extra dependencies:
+```bash
+uv tool install 'sendspin[cast]'
+```
+
 **Install as daemon (Linux):**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Sendspin/sendspin-cli/refs/heads/main/scripts/systemd/install-systemd.sh | sudo bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "aiosendspin-mpris~=2.1.1",
   "av>=14.0.0",
   "numpy>=1.24.0",
-  "pychromecast>=14.0.0",
   "pulsectl-asyncio>=1.2.2; platform_system == 'Linux'",
   "qrcode>=8.0",
   "readchar>=4.0.0",
@@ -40,6 +39,7 @@ version = "0.0.0"
 sendspin = "sendspin.cli:main"
 
 [project.optional-dependencies]
+cast = ["pychromecast>=14.0.0"]
 test = [
   "codespell==2.4.1",
   "mypy==1.18.2",

--- a/sendspin/discovery.py
+++ b/sendspin/discovery.py
@@ -252,18 +252,29 @@ async def discover_clients(discovery_time: float = 3.0) -> list[DiscoveredClient
     Returns:
         List of discovered clients (Sendspin clients and Chromecast devices).
     """
-    from pychromecast.discovery import CastBrowser, SimpleCastListener
+    try:
+        from pychromecast.discovery import CastBrowser, SimpleCastListener
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"pychromecast", "pychromecast.discovery"}:
+            raise
+        CastBrowser = None
+        SimpleCastListener = None
+        logger.debug(
+            "Chromecast discovery disabled because the optional cast extra is not installed"
+        )
 
     loop = asyncio.get_running_loop()
     sendspin_listener = _ClientDiscoveryListener(loop)
 
     async with AsyncZeroconf() as zeroconf:
-        # Start Chromecast discovery (non-blocking)
-        chromecast_browser = CastBrowser(
-            SimpleCastListener(),
-            zeroconf.zeroconf,
-        )
-        chromecast_browser.start_discovery()
+        chromecast_browser = None
+        if CastBrowser is not None and SimpleCastListener is not None:
+            # Start Chromecast discovery (non-blocking) when the optional dependency is present.
+            chromecast_browser = CastBrowser(
+                SimpleCastListener(),
+                zeroconf.zeroconf,
+            )
+            chromecast_browser.start_discovery()
 
         try:
             # Browse Sendspin clients (non-blocking)
@@ -278,19 +289,21 @@ async def discover_clients(discovery_time: float = 3.0) -> list[DiscoveredClient
 
             # Collect Chromecast results
             chromecast_clients: list[DiscoveredClient] = []
-            for cc in chromecast_browser.devices.values():
-                host = cc.host
-                port = cc.port
-                name = cc.friendly_name or f"Chromecast ({host})"
-                host_fmt = f"[{host}]" if ":" in host else host
-                url = f"cast://{host_fmt}:{port}"
-                chromecast_clients.append(
-                    DiscoveredClient(name=name, url=url, host=host, port=port)
-                )
+            if chromecast_browser is not None:
+                for cc in chromecast_browser.devices.values():
+                    host = cc.host
+                    port = cc.port
+                    name = cc.friendly_name or f"Chromecast ({host})"
+                    host_fmt = f"[{host}]" if ":" in host else host
+                    url = f"cast://{host_fmt}:{port}"
+                    chromecast_clients.append(
+                        DiscoveredClient(name=name, url=url, host=host, port=port)
+                    )
 
             return [
                 *sendspin_listener.clients.values(),
                 *chromecast_clients,
             ]
         finally:
-            chromecast_browser.stop_discovery()
+            if chromecast_browser is not None:
+                chromecast_browser.stop_discovery()

--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -1,5 +1,7 @@
 """Sendspin server application."""
 
+from __future__ import annotations
+
 import asyncio
 import errno
 import logging
@@ -11,6 +13,7 @@ import sys
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import qrcode
 from aiosendspin.server import (
@@ -24,16 +27,28 @@ from aiosendspin.server.push_stream import PushStream
 
 from sendspin.utils import create_task
 
-from .chromecast import (
-    ChromecastClient,
-    connect_to_chromecast,
-    disconnect_chromecast,
-    parse_cast_url,
-)
 from .server import SendspinPlayerServer
 from .source import AudioSource, decode_audio
 
+if TYPE_CHECKING:
+    from .chromecast import ChromecastClient
+
 logger = logging.getLogger(__name__)
+
+CAST_INSTALL_HINT = "Install the optional cast extra with `pip install 'sendspin[cast]'`."
+
+
+def _load_chromecast_support() -> Any:
+    """Import Chromecast support only when it is explicitly used."""
+    try:
+        from . import chromecast
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"pychromecast", "pychromecast.discovery"}:
+            raise
+        raise RuntimeError(
+            f"Chromecast support requires the optional 'cast' extra. {CAST_INSTALL_HINT}"
+        ) from exc
+    return chromecast
 
 
 def print_qr_code(url: str) -> None:
@@ -191,11 +206,13 @@ async def run_server(config: ServeConfig) -> int:
             try:
                 print(f"Connecting to client: {client_url}")
                 if client_url.startswith("cast://"):
-                    host, _ = parse_cast_url(client_url)
+                    chromecast = _load_chromecast_support()
+
+                    host, _ = chromecast.parse_cast_url(client_url)
                     # Replace non-alphanumeric chars with dashes (handles IPv4 and IPv6)
                     safe_host = re.sub(r"[^a-zA-Z0-9]", "-", host)
                     player_id = f"cast-{safe_host}"
-                    cc_client = await connect_to_chromecast(
+                    cc_client = await chromecast.connect_to_chromecast(
                         url=client_url,
                         server_url=server_url,
                         player_id=player_id,
@@ -260,8 +277,11 @@ async def run_server(config: ServeConfig) -> int:
 
     finally:
         with suppress(Exception):
-            for cc_client in chromecast_clients:
-                await disconnect_chromecast(cc_client)
+            if chromecast_clients:
+                chromecast = _load_chromecast_support()
+
+                for cc_client in chromecast_clients:
+                    await chromecast.disconnect_chromecast(cc_client)
 
             await server.close()
 


### PR DESCRIPTION
pychromecast is a heavy dependency. Moving it to optional as it's really a tiny feature for `sendspin serve` to make outbound connections

## Summary
- move `pychromecast` into a new optional `cast` extra
- only import Chromecast support when `cast://` clients or Chromecast discovery are used
- document the optional install path for Chromecast support

## Testing
- `uv run --extra test pre-commit run --all-files`