### PR TITLE
Prefer well-known ALSA mixer element names

### DIFF
--- a/sendspin/alsa_volume.py
+++ b/sendspin/alsa_volume.py
@@ -27,6 +27,13 @@ _SWITCH_RE = re.compile(r"\[(on|off)\]")
 
 _POLL_INTERVAL_S = 1.0
 
+# Well-known ALSA mixer element names, in priority order.
+# When multiple elements have playback volume, prefer these over others.
+# - Digital: HiFiBerry DAC+/DAC2/Amp2, most I2S DAC HATs (PCM5122)
+# - Master: HiFiBerry Amp+, generic ALSA cards, many USB interfaces
+# - PCM: bcm2835 headphones, some USB DACs
+_PREFERRED_ELEMENTS: tuple[str, ...] = ("Digital", "Master", "PCM")
+
 
 def parse_alsa_card(device_name: str) -> int | None:
     """Extract the ALSA card number from a PortAudio device name.
@@ -65,8 +72,10 @@ async def find_mixer_element(card: int) -> str | None:
     """Discover the playback volume mixer element on an ALSA card.
 
     Runs ``amixer -c <card> scontrols``, then checks each element for
-    playback volume (``pvolume``) capability.  Returns the first match,
-    or None if no element has playback volume control.
+    playback volume (``pvolume``) capability.  Prefers well-known element
+    names (Digital, Master, PCM) when multiple elements have playback
+    volume.  Returns the best match, or None if no element has playback
+    volume control.
     """
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -92,20 +101,32 @@ async def find_mixer_element(card: int) -> str | None:
         return None
 
     seen: set[str] = set()
+    pvolume_elements: list[str] = []
     for element in available:
         if element in seen:
             continue
         seen.add(element)
         if await _has_playback_volume(card, element):
-            logger.debug("ALSA card %d: selected mixer element %r", card, element)
-            return element
+            pvolume_elements.append(element)
 
-    logger.debug(
-        "ALSA card %d: no playback volume element among %s",
-        card,
-        sorted(seen),
-    )
-    return None
+    if not pvolume_elements:
+        logger.debug(
+            "ALSA card %d: no playback volume element among %s",
+            card,
+            sorted(seen),
+        )
+        return None
+
+    # Prefer well-known element names used by common DAC HATs.
+    for preferred in _PREFERRED_ELEMENTS:
+        if preferred in pvolume_elements:
+            logger.debug("ALSA card %d: selected preferred mixer element %r", card, preferred)
+            return preferred
+
+    # Fallback: first element with pvolume (e.g. USB DACs with non-standard names).
+    selected = pvolume_elements[0]
+    logger.debug("ALSA card %d: selected mixer element %r", card, selected)
+    return selected
 
 
 async def async_check_alsa_available(

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -79,14 +79,28 @@ def test_find_mixer_element_digital(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=scontrols.encode())
-        # 'Analogue' is first in scontrols but has pvolume too; however
-        # the real HiFiBerry lists it before Digital. We simulate that
-        # only 'Digital' has pvolume to test the scan skips non-pvolume.
-        if "Analogue" in argv:
-            return _FakeProcess(stdout=sget_without_pvolume.encode())
-        if "Digital" in argv:
+        # On real HiFiBerry DAC+ (PCM5122), both Analogue and Digital
+        # have pvolume. The preference logic should pick Digital.
+        if "Analogue" in argv or "Digital" in argv:
             return _FakeProcess(stdout=sget_with_pvolume.encode())
         return _FakeProcess(stdout=sget_without_pvolume.encode())
+
+    async def exercise() -> str | None:
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        return await find_mixer_element(1)
+
+    assert asyncio.run(exercise()) == "Digital"
+
+
+def test_find_mixer_element_prefers_digital_over_analogue(monkeypatch) -> None:
+    """When both Analogue and Digital have pvolume, Digital is preferred."""
+    scontrols = "Simple mixer control 'Analogue',0\nSimple mixer control 'Digital',0\n"
+    sget_with_pvolume = "  Capabilities: pvolume pswitch\n"
+
+    async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
+        if "scontrols" in argv:
+            return _FakeProcess(stdout=scontrols.encode())
+        return _FakeProcess(stdout=sget_with_pvolume.encode())
 
     async def exercise() -> str | None:
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
@@ -419,7 +433,8 @@ def test_hifiberry_dac_discovery(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=_HIFIBERRY_SCONTROLS.encode())
-        if "Digital" in argv:
+        # Both Analogue and Digital have pvolume on real hardware.
+        if "Analogue" in argv or "Digital" in argv:
             return _FakeProcess(stdout=sget_with_pvolume.encode())
         return _FakeProcess(stdout=sget_without_pvolume.encode())
 


### PR DESCRIPTION
On HiFiBerry DAC+ both Analogue and Digital have pvolume, but Analogue was selected first alphabetically. Digital is the correct control on these boards.

Closes #156