### PR TITLE
Bump sendspin-js to 2.0.4

### DIFF
--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -644,7 +644,7 @@ elements.listenToggleBtn.addEventListener("click", async () => {
 });
 
 const sdkImport = import(
-  "https://unpkg.com/@sendspin/sendspin-js@2.0.3/dist/index.js?module",
+  "https://unpkg.com/@sendspin/sendspin-js@2.0.4/dist/index.js?module",
 );
 
 // QR Code generation (using qrcode-generator loaded via script tag)


### PR DESCRIPTION
sendspin-js 2.0.4 now includes built-in default sync delay values per platform/browser making the web client running with `sendspin serve` more in sync.