### PR TITLE
Fix TUI redraw after event-driven updates

### DIFF
--- a/sendspin/tui/ui.py
+++ b/sendspin/tui/ui.py
@@ -203,6 +203,7 @@ class SendspinUI:
                 break
             else:
                 event.clear()
+                self._flush_refresh()
 
     def _shortcut_style(self, shortcut: str) -> str:
         """Get the style for a shortcut key."""


### PR DESCRIPTION
## Summary
- flush the live view when the UI refresh loop wakes up from an event-driven refresh request

## Testing
- ./scripts/run-in-env.sh pytest tests/tui/test_volume_state.py
- ./scripts/run-in-env.sh ruff check sendspin/tui/ui.py