### PR TITLE
Add multi-worker serve mode for Sendspin Party

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,3 +390,15 @@ uvx sendspin serve /path/to/media.mp3
 # Connect to specific clients
 sendspin serve --demo --client ws://192.168.1.50:8927/sendspin --client ws://192.168.1.51:8927/sendspin
 ```
+
+### Multi-Worker Mode
+
+For serving many concurrent listeners, use `--workers` to run multiple server processes behind a reverse proxy:
+
+```bash
+sendspin serve --demo --workers 4
+```
+
+This spawns 4 worker processes on consecutive ports starting from `--port` (default 8927), so ports 8927-8930. Place a reverse proxy (e.g., nginx, Caddy) in front with load balancing across these ports.
+
+Note: `--client` is not supported with `--workers`.

--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -549,6 +549,10 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
         print("Error: --workers must be at least 1")
         return 1
 
+    if args.workers > 1 and serve_config.clients:
+        print("Error: --client is not supported with --workers")
+        return 1
+
     if args.workers > 1:
         return await run_server_multi(serve_config, workers=args.workers, log_level=args.log_level)
 

--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -291,6 +291,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
         help="Client URL to connect to (can be specified multiple times)",
     )
+    serve_parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of server worker processes (default: 1)",
+    )
 
     # Daemon subcommand
     daemon_parser = subparsers.add_parser(
@@ -503,7 +509,7 @@ def _resolve_preferred_format(
 
 async def _run_serve_mode(args: argparse.Namespace) -> int:
     """Run the server mode."""
-    from sendspin.serve import ServeConfig, run_server
+    from sendspin.serve import ServeConfig, run_server, run_server_multi
 
     # Load settings for serve mode
     settings = await get_serve_settings()
@@ -539,6 +545,9 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
         name=args.name,
         clients=args.clients or settings.clients,
     )
+    if args.workers > 1:
+        return await run_server_multi(serve_config, workers=args.workers, log_level=args.log_level)
+
     return await run_server(serve_config)
 
 

--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -545,6 +545,10 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
         name=args.name,
         clients=args.clients or settings.clients,
     )
+    if args.workers < 1:
+        print("Error: --workers must be at least 1")
+        return 1
+
     if args.workers > 1:
         return await run_server_multi(serve_config, workers=args.workers, log_level=args.log_level)
 

--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -286,3 +286,18 @@ async def run_server(config: ServeConfig) -> int:
             await server.close()
 
     return 0
+
+
+async def run_server_multi(config: ServeConfig, *, workers: int, log_level: str) -> int:
+    """Run the multi-worker Sendspin server."""
+    from sendspin.serve.coordinator import ServeCoordinator
+
+    coordinator = ServeCoordinator(
+        source=config.source,
+        source_format=config.source_format,
+        port=config.port,
+        name=config.name,
+        workers=workers,
+        log_level=log_level,
+    )
+    return await coordinator.run()

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -2,8 +2,7 @@
 
 The coordinator is the main process. It spawns worker subprocesses, decodes
 the audio source, and fans out PCM chunks with shared timestamps to all workers.
-It also runs an HTTP server that round-robin redirects browsers to worker ports
-and serves an aggregated client count endpoint.
+Workers are standalone HTTP+WS servers; put a reverse proxy in front for load balancing.
 """
 
 from __future__ import annotations
@@ -16,10 +15,9 @@ import signal
 import time
 from contextlib import suppress
 
-from aiohttp import web
 from aiosendspin.server.push_stream import DEFAULT_INITIAL_DELAY_US
 
-from sendspin.serve import get_local_ip, print_qr_code
+from sendspin.serve import get_local_ip
 from sendspin.serve.ipc import (
     AudioChunk,
     Shutdown,
@@ -60,16 +58,13 @@ class ServeCoordinator:
         self._audio_queues: list[mp.Queue] = []  # type: ignore[type-arg]
         self._status_queue: mp.Queue = self._ctx.Queue()  # type: ignore[type-arg]
         self._processes: list[mp.process.BaseProcess] = []
+        self._total_listeners: mp.sharedctypes.Synchronized[int] = self._ctx.Value("i", 0)
 
         # State
         self._client_counts: dict[int, int] = {}
         self._shutdown_requested = False
         self._client_connected_event = asyncio.Event()
-        self._active_worker_ports: list[int] = []
         self._run_task: asyncio.Task[int] | None = None
-
-        # HTTP server
-        self._http_runner: web.AppRunner | None = None
 
     async def run(self) -> int:
         """Main coordinator loop."""
@@ -83,7 +78,6 @@ class ServeCoordinator:
         try:
             self._spawn_workers()
             await self._wait_for_workers_listening()
-            await self._start_http_server()
             self._print_banner()
 
             # Wait for first client on any worker
@@ -113,9 +107,6 @@ class ServeCoordinator:
 
     def _spawn_workers(self) -> None:
         """Spawn worker subprocesses."""
-        local_ip = get_local_ip()
-        coordinator_url = f"http://{local_ip}:{self.port}"
-
         for i in range(self.workers):
             audio_queue: mp.Queue = self._ctx.Queue()  # type: ignore[type-arg]
             self._audio_queues.append(audio_queue)
@@ -127,7 +118,7 @@ class ServeCoordinator:
                     self.worker_ports[i],
                     audio_queue,
                     self._status_queue,
-                    coordinator_url,
+                    self._total_listeners,
                     self.log_level,
                 ),
             )
@@ -146,7 +137,6 @@ class ServeCoordinator:
 
             if isinstance(msg, WorkerListening):
                 listening_count += 1
-                self._active_worker_ports.append(msg.port)
                 logger.info(
                     "Worker %d listening on port %d (%d/%d)",
                     msg.worker_id,
@@ -183,6 +173,7 @@ class ServeCoordinator:
             logger.info("Client %s connected to worker %d", msg.client_id, msg.worker_id)
         elif isinstance(msg, WorkerClientCount):
             self._client_counts[msg.worker_id] = msg.count
+            self._total_listeners.value = sum(self._client_counts.values())
         elif isinstance(msg, WorkerError):
             logger.error("Worker %d error: %s", msg.worker_id, msg.error)
 
@@ -196,16 +187,15 @@ class ServeCoordinator:
                 break
 
     def _check_worker_health(self) -> None:
-        """Check for crashed workers and remove them from the redirect pool."""
-        for i, proc in enumerate(self._processes):
-            if proc.is_alive():
-                continue
-            port = self.worker_ports[i]
-            if port in self._active_worker_ports:
-                self._active_worker_ports.remove(port)
-                print(f"[health] Worker {i} (port {port}) crashed, removed from pool")  # noqa: T201
+        """Check for crashed workers."""
+        alive_count = sum(1 for p in self._processes if p.is_alive())
 
-        if not self._active_worker_ports and self._processes:
+        for i, proc in enumerate(self._processes):
+            if not proc.is_alive():
+                port = self.worker_ports[i]
+                print(f"[health] Worker {i} (port {port}) crashed")  # noqa: T201
+
+        if alive_count == 0 and self._processes:
             print("[health] All workers have crashed, shutting down")  # noqa: T201
             self._shutdown_requested = True
             if self._run_task is not None:
@@ -278,70 +268,14 @@ class ServeCoordinator:
                 print(f"Retrying in {delay}s...")  # noqa: T201
                 await asyncio.sleep(delay)
 
-    async def _start_http_server(self) -> None:
-        """Start the coordinator HTTP server for redirects and status."""
-        local_ip = get_local_ip()
-        active_ports = self._active_worker_ports
-
-        app = web.Application()
-
-        redirect_index = 0
-
-        async def redirect_handler(request: web.Request) -> web.Response:
-            nonlocal redirect_index
-            if not active_ports:
-                return web.Response(text="No workers available", status=503)
-            port = active_ports[redirect_index % len(active_ports)]
-            redirect_index += 1
-            return web.Response(
-                status=307,
-                headers={
-                    "Location": f"http://{local_ip}:{port}/",
-                    "Cache-Control": "no-store",
-                },
-            )
-
-        client_counts = self._client_counts
-
-        async def status_handler(request: web.Request) -> web.Response:
-            total = sum(client_counts.values())
-            return web.json_response(
-                {"total_clients": total},
-                headers={"Access-Control-Allow-Origin": "*"},
-            )
-
-        app.router.add_get("/", redirect_handler)
-        app.router.add_get("/api/status", status_handler)
-
-        self._http_runner = web.AppRunner(app)
-        await self._http_runner.setup()
-        site = web.TCPSite(self._http_runner, port=self.port)
-        await site.start()
-
-    async def _stop_http_server(self) -> None:
-        """Stop the coordinator HTTP server."""
-        if self._http_runner is not None:
-            await self._http_runner.cleanup()
-            self._http_runner = None
-
     def _print_banner(self) -> None:
-        """Print the server URLs and QR code."""
+        """Print worker URLs."""
         local_ip = get_local_ip()
-        url = f"http://{local_ip}:{self.port}/"
 
         print(f"\nMulti-worker server running ({self.workers} workers)")  # noqa: T201
-        for i, port in enumerate(self._active_worker_ports):
+        for i, port in enumerate(self.worker_ports):
             print(f"  Worker {i}: http://{local_ip}:{port}/")  # noqa: T201
-        print(f"\nEntry point: {url}")  # noqa: T201
-
-        if local_ip != "localhost":
-            print()  # noqa: T201
-            print_qr_code(url)
-            print()  # noqa: T201
-            print("Scan QR to open in browser to use the web player")  # noqa: T201
-        else:
-            print("Unable to print QR code because no LAN IP available")  # noqa: T201
-            print("Open in browser to use the web player")  # noqa: T201
+        print("\nPlace a reverse proxy in front of the worker ports for load balancing.")  # noqa: T201
         print("Press Ctrl+C to quit\n")  # noqa: T201
 
     async def _shutdown(self) -> None:
@@ -358,5 +292,3 @@ class ServeCoordinator:
                 p.terminate()
         for p in self._processes:
             p.join(timeout=2.0)
-
-        await self._stop_http_server()

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -67,6 +67,7 @@ class ServeCoordinator:
         self._client_counts: dict[int, int] = {}
         self._shutdown_requested = False
         self._run_task: asyncio.Task[int] | None = None
+        self._failed_workers: set[int] = set()
         self._reported_crashed: set[int] = set()
 
     async def run(self) -> int:
@@ -159,6 +160,9 @@ class ServeCoordinator:
                 failed_workers.add(msg.worker_id)
                 logger.error("Worker %d error during startup: %s", msg.worker_id, msg.error)
 
+        self._failed_workers = failed_workers
+        self._reported_crashed.update(failed_workers)
+
         if failed_workers and self._audio_queues:
             # Remove audio queues for failed workers so we don't push into dead queues
             for wid in sorted(failed_workers, reverse=True):
@@ -208,6 +212,8 @@ class ServeCoordinator:
     def _check_worker_health(self) -> None:
         """Check for crashed workers - shut down if any died."""
         for i, proc in enumerate(self._processes):
+            if i in self._failed_workers:
+                continue
             if not proc.is_alive() and i not in self._reported_crashed:
                 self._reported_crashed.add(i)
                 port = self.worker_ports[i]
@@ -297,8 +303,11 @@ class ServeCoordinator:
         """Print worker URLs."""
         local_ip = get_local_ip()
 
-        print(f"\nMulti-worker server running ({self.workers} workers)")  # noqa: T201
-        for i, port in enumerate(self.worker_ports):
+        healthy_workers = [i for i in range(self.workers) if i not in self._failed_workers]
+
+        print(f"\nMulti-worker server running ({len(healthy_workers)} workers)")  # noqa: T201
+        for i in healthy_workers:
+            port = self.worker_ports[i]
             print(f"  Worker {i}: http://{local_ip}:{port}/")  # noqa: T201
         print("\nPlace a reverse proxy in front of the worker ports for load balancing.")  # noqa: T201
         print("Press Ctrl+C to quit\n")  # noqa: T201

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -31,6 +31,8 @@ from sendspin.serve.worker import worker_main
 
 logger = logging.getLogger(__name__)
 
+MAX_BUFFER_AHEAD_US = 5_000_000  # Keep at least 5s of buffer on workers
+
 
 class ServeCoordinator:
     """Orchestrates multi-worker serve mode."""
@@ -252,8 +254,8 @@ class ServeCoordinator:
 
                     now_us = int(time.monotonic() * 1_000_000)
                     ahead_us = play_start_us - DEFAULT_INITIAL_DELAY_US - now_us
-                    if ahead_us > 0:
-                        await asyncio.sleep(ahead_us / 1_000_000)
+                    if ahead_us > MAX_BUFFER_AHEAD_US:
+                        await asyncio.sleep((ahead_us - MAX_BUFFER_AHEAD_US) / 1_000_000)
 
                 consecutive_errors = 0
 

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -1,0 +1,323 @@
+"""Coordinator for multi-worker serve mode.
+
+The coordinator is the main process. It spawns worker subprocesses, decodes
+the audio source, and fans out PCM chunks with shared timestamps to all workers.
+It also runs an HTTP server that round-robin redirects browsers to worker ports
+and serves an aggregated client count endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing as mp
+import signal
+import time
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+from aiosendspin.server.push_stream import DEFAULT_INITIAL_DELAY_US
+
+from sendspin.serve import get_local_ip, print_qr_code
+from sendspin.serve.ipc import (
+    AudioChunk,
+    Shutdown,
+    WorkerClientConnected,
+    WorkerClientCount,
+    WorkerError,
+    WorkerListening,
+)
+from sendspin.serve.source import decode_audio
+from sendspin.serve.worker import worker_main
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class ServeCoordinator:
+    """Orchestrates multi-worker serve mode."""
+
+    def __init__(
+        self,
+        *,
+        source: str,
+        source_format: str | None,
+        port: int,
+        name: str,
+        workers: int,
+        log_level: str,
+    ) -> None:
+        self.source = source
+        self.source_format = source_format
+        self.port = port
+        self.name = name
+        self.workers = workers
+        self.log_level = log_level
+        self.worker_ports = [port + 1 + i for i in range(workers)]
+
+        # IPC
+        self._ctx = mp.get_context("spawn")
+        self._audio_queues: list[mp.Queue] = []  # type: ignore[type-arg]
+        self._status_queue: mp.Queue = self._ctx.Queue()  # type: ignore[type-arg]
+        self._processes: list[mp.process.BaseProcess] = []
+
+        # State
+        self._client_counts: dict[int, int] = {}
+        self._shutdown_requested = False
+        self._client_connected_event = asyncio.Event()
+        self._active_worker_ports: list[int] = []
+
+        # HTTP server
+        self._http_runner: web.AppRunner | None = None
+
+    async def run(self) -> int:
+        """Main coordinator loop."""
+        loop = asyncio.get_running_loop()
+
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(signal.SIGINT, self._handle_sigint)
+
+        try:
+            self._spawn_workers()
+            await self._wait_for_workers_listening()
+            await self._start_http_server()
+            self._print_banner()
+
+            # Wait for first client on any worker
+            await self._consume_status_until_client()
+
+            # Decode and fan out audio
+            await self._stream_audio_loop()
+
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await self._shutdown()
+
+        return 0
+
+    def _handle_sigint(self) -> None:
+        self._shutdown_requested = True
+        print("\nShutting down...")  # noqa: T201
+        self._client_connected_event.set()
+
+    def _spawn_workers(self) -> None:
+        """Spawn worker subprocesses."""
+        local_ip = get_local_ip()
+        coordinator_url = f"http://{local_ip}:{self.port}"
+
+        for i in range(self.workers):
+            audio_queue: mp.Queue = self._ctx.Queue()  # type: ignore[type-arg]
+            self._audio_queues.append(audio_queue)
+
+            p = self._ctx.Process(
+                target=worker_main,
+                args=(
+                    i,
+                    self.worker_ports[i],
+                    audio_queue,
+                    self._status_queue,
+                    coordinator_url,
+                    self.log_level,
+                ),
+            )
+            p.start()
+            self._processes.append(p)
+
+        logger.info("Spawned %d worker processes", self.workers)
+
+    async def _wait_for_workers_listening(self) -> None:
+        """Wait for all workers to report they are listening."""
+        loop = asyncio.get_running_loop()
+        listening_count = 0
+
+        while listening_count < self.workers:
+            msg = await loop.run_in_executor(None, self._status_queue.get)
+
+            if isinstance(msg, WorkerListening):
+                listening_count += 1
+                self._active_worker_ports.append(msg.port)
+                logger.info(
+                    "Worker %d listening on port %d (%d/%d)",
+                    msg.worker_id,
+                    msg.port,
+                    listening_count,
+                    self.workers,
+                )
+            elif isinstance(msg, WorkerError):
+                logger.error("Worker %d error during startup: %s", msg.worker_id, msg.error)
+                listening_count += 1
+
+    async def _consume_status_until_client(self) -> None:
+        """Process status messages until at least one client connects or shutdown."""
+        loop = asyncio.get_running_loop()
+
+        while not self._shutdown_requested:
+            try:
+                msg = await asyncio.wait_for(
+                    loop.run_in_executor(None, self._status_queue.get),
+                    timeout=0.5,
+                )
+                self._handle_status_message(msg)
+                if isinstance(msg, WorkerClientConnected):
+                    return
+            except TimeoutError:
+                continue
+
+    def _handle_status_message(self, msg: object) -> None:
+        """Handle a single status message from a worker."""
+        if isinstance(msg, WorkerClientConnected):
+            logger.info("Client %s connected to worker %d", msg.client_id, msg.worker_id)
+        elif isinstance(msg, WorkerClientCount):
+            self._client_counts[msg.worker_id] = msg.count
+        elif isinstance(msg, WorkerError):
+            logger.error("Worker %d error: %s", msg.worker_id, msg.error)
+
+    async def _drain_status_queue(self) -> None:
+        """Non-blocking drain of pending status messages."""
+        while True:
+            try:
+                msg = self._status_queue.get_nowait()
+                self._handle_status_message(msg)
+            except Exception:  # noqa: BLE001
+                break
+
+    async def _stream_audio_loop(self) -> None:
+        """Decode audio and fan out PCM chunks to all workers."""
+        consecutive_errors = 0
+
+        while not self._shutdown_requested:
+            try:
+                audio_source = await decode_audio(self.source, source_format=self.source_format)
+                fmt = audio_source.format
+
+                play_start_us = int(time.monotonic() * 1_000_000) + DEFAULT_INITIAL_DELAY_US
+
+                async for pcm_chunk in audio_source.generator:
+                    if self._shutdown_requested:
+                        break  # type: ignore[unreachable]
+
+                    await self._drain_status_queue()
+
+                    frame_stride = (fmt.bit_depth // 8) * fmt.channels
+                    sample_count = len(pcm_chunk) // frame_stride
+                    chunk_duration_us = int(sample_count * 1_000_000 / fmt.sample_rate)
+
+                    chunk_msg = AudioChunk(
+                        pcm_bytes=pcm_chunk,
+                        sample_rate=fmt.sample_rate,
+                        bit_depth=fmt.bit_depth,
+                        channels=fmt.channels,
+                        play_start_us=play_start_us,
+                    )
+                    for queue in self._audio_queues:
+                        queue.put(chunk_msg)
+
+                    play_start_us += chunk_duration_us
+
+                    now_us = int(time.monotonic() * 1_000_000)
+                    ahead_us = play_start_us - DEFAULT_INITIAL_DELAY_US - now_us
+                    if ahead_us > 0:
+                        await asyncio.sleep(ahead_us / 1_000_000)
+
+                consecutive_errors = 0
+
+            except asyncio.CancelledError:
+                break
+            except FileNotFoundError as e:
+                print(f"Error: {e}")  # noqa: T201
+                return
+            except Exception as e:  # noqa: BLE001
+                consecutive_errors += 1
+                delay = min(2**consecutive_errors, 30)
+                print(f"Playback error: {e}")  # noqa: T201
+                logger.debug("Playback error", exc_info=True)
+                print(f"Retrying in {delay}s...")  # noqa: T201
+                await asyncio.sleep(delay)
+
+    async def _start_http_server(self) -> None:
+        """Start the coordinator HTTP server for redirects and status."""
+        local_ip = get_local_ip()
+        worker_urls = [f"http://{local_ip}:{p}/" for p in self._active_worker_ports]
+
+        # If no workers reported listening yet, use calculated ports
+        if not worker_urls:
+            worker_urls = [f"http://{local_ip}:{p}/" for p in self.worker_ports]
+
+        app = web.Application()
+
+        redirect_index = 0
+
+        async def redirect_handler(request: web.Request) -> web.Response:
+            nonlocal redirect_index
+            if not worker_urls:
+                return web.Response(text="No workers available", status=503)
+            url = worker_urls[redirect_index % len(worker_urls)]
+            redirect_index += 1
+            return web.Response(
+                status=307,
+                headers={
+                    "Location": url,
+                    "Cache-Control": "no-store",
+                },
+            )
+
+        client_counts = self._client_counts
+
+        async def status_handler(request: web.Request) -> web.Response:
+            total = sum(client_counts.values())
+            return web.json_response({"total_clients": total})
+
+        app.router.add_get("/", redirect_handler)
+        app.router.add_get("/api/status", status_handler)
+
+        self._http_runner = web.AppRunner(app)
+        await self._http_runner.setup()
+        site = web.TCPSite(self._http_runner, port=self.port)
+        await site.start()
+
+    async def _stop_http_server(self) -> None:
+        """Stop the coordinator HTTP server."""
+        if self._http_runner is not None:
+            await self._http_runner.cleanup()
+            self._http_runner = None
+
+    def _print_banner(self) -> None:
+        """Print the server URLs and QR code."""
+        local_ip = get_local_ip()
+        url = f"http://{local_ip}:{self.port}/"
+
+        print(f"\nMulti-worker server running ({self.workers} workers)")  # noqa: T201
+        for i, port in enumerate(self._active_worker_ports):
+            print(f"  Worker {i}: http://{local_ip}:{port}/")  # noqa: T201
+        print(f"\nEntry point: {url}")  # noqa: T201
+
+        if local_ip != "localhost":
+            print()  # noqa: T201
+            print_qr_code(url)
+            print()  # noqa: T201
+            print("Scan QR to open in browser to use the web player")  # noqa: T201
+        else:
+            print("Unable to print QR code because no LAN IP available")  # noqa: T201
+            print("Open in browser to use the web player")  # noqa: T201
+        print("Press Ctrl+C to quit\n")  # noqa: T201
+
+    async def _shutdown(self) -> None:
+        """Gracefully shut down all workers."""
+        for queue in self._audio_queues:
+            with suppress(Exception):
+                queue.put(Shutdown())
+
+        for p in self._processes:
+            p.join(timeout=5.0)
+
+        for p in self._processes:
+            if p.is_alive():
+                p.terminate()
+        for p in self._processes:
+            p.join(timeout=2.0)
+
+        await self._stop_http_server()

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -65,6 +65,7 @@ class ServeCoordinator:
         self._shutdown_requested = False
         self._client_connected_event = asyncio.Event()
         self._run_task: asyncio.Task[int] | None = None
+        self._reported_crashed: set[int] = set()
 
     async def run(self) -> int:
         """Main coordinator loop."""
@@ -191,7 +192,8 @@ class ServeCoordinator:
         alive_count = sum(1 for p in self._processes if p.is_alive())
 
         for i, proc in enumerate(self._processes):
-            if not proc.is_alive():
+            if not proc.is_alive() and i not in self._reported_crashed:
+                self._reported_crashed.add(i)
                 port = self.worker_ports[i]
                 print(f"[health] Worker {i} (port {port}) crashed")  # noqa: T201
 

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -86,11 +86,14 @@ class ServeCoordinator:
                 return 1
             self._print_banner()
 
-            # Wait for first client on any worker
-            await self._consume_status_until_client()
+            while not self._shutdown_requested:
+                # Wait for at least one client on any worker
+                await self._consume_status_until_client()
+                if self._shutdown_requested:
+                    break  # type: ignore[unreachable]
 
-            # Decode and fan out audio
-            await self._stream_audio_loop()
+                # Decode and fan out audio until all clients disconnect
+                await self._stream_audio_loop()
 
         except asyncio.CancelledError:
             pass
@@ -223,7 +226,10 @@ class ServeCoordinator:
         print(f"[stats] {total} clients connected ({summary})")  # noqa: T201
 
     async def _stream_audio_loop(self) -> None:
-        """Decode audio and fan out PCM chunks to all workers."""
+        """Decode audio and fan out PCM chunks to all workers.
+
+        Returns when all clients disconnect or shutdown is requested.
+        """
         consecutive_errors = 0
         last_stats_time = time.monotonic()
 
@@ -239,6 +245,11 @@ class ServeCoordinator:
                         break  # type: ignore[unreachable]
 
                     await self._drain_status_queue()
+
+                    # Pause if all clients disconnected
+                    if self._total_listeners.value == 0:
+                        logger.info("All clients disconnected, pausing playback")
+                        return
 
                     now = time.monotonic()
                     if now - last_stats_time >= 30.0:
@@ -270,9 +281,10 @@ class ServeCoordinator:
                 consecutive_errors = 0
 
             except asyncio.CancelledError:
-                break
+                return
             except FileNotFoundError as e:
                 print(f"Error: {e}")  # noqa: T201
+                self._shutdown_requested = True
                 return
             except Exception as e:  # noqa: BLE001
                 consecutive_errors += 1

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -15,7 +15,6 @@ import queue as _queue
 import signal
 import time
 from contextlib import suppress
-from typing import TYPE_CHECKING
 
 from aiohttp import web
 from aiosendspin.server.push_stream import DEFAULT_INITIAL_DELAY_US
@@ -31,9 +30,6 @@ from sendspin.serve.ipc import (
 )
 from sendspin.serve.source import decode_audio
 from sendspin.serve.worker import worker_main
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -196,8 +192,24 @@ class ServeCoordinator:
             try:
                 msg = self._status_queue.get_nowait()
                 self._handle_status_message(msg)
-            except Exception:  # noqa: BLE001
+            except _queue.Empty:
                 break
+
+    def _check_worker_health(self) -> None:
+        """Check for crashed workers and remove them from the redirect pool."""
+        for i, proc in enumerate(self._processes):
+            if proc.is_alive():
+                continue
+            port = self.worker_ports[i]
+            if port in self._active_worker_ports:
+                self._active_worker_ports.remove(port)
+                print(f"[health] Worker {i} (port {port}) crashed, removed from pool")  # noqa: T201
+
+        if not self._active_worker_ports and self._processes:
+            print("[health] All workers have crashed, shutting down")  # noqa: T201
+            self._shutdown_requested = True
+            if self._run_task is not None:
+                self._run_task.cancel()
 
     def _log_client_stats(self) -> None:
         """Print per-worker client counts to console."""
@@ -226,6 +238,7 @@ class ServeCoordinator:
 
                     now = time.monotonic()
                     if now - last_stats_time >= 30.0:
+                        self._check_worker_health()
                         self._log_client_stats()
                         last_stats_time = now
 
@@ -268,11 +281,7 @@ class ServeCoordinator:
     async def _start_http_server(self) -> None:
         """Start the coordinator HTTP server for redirects and status."""
         local_ip = get_local_ip()
-        worker_urls = [f"http://{local_ip}:{p}/" for p in self._active_worker_ports]
-
-        # If no workers reported listening yet, use calculated ports
-        if not worker_urls:
-            worker_urls = [f"http://{local_ip}:{p}/" for p in self.worker_ports]
+        active_ports = self._active_worker_ports
 
         app = web.Application()
 
@@ -280,14 +289,14 @@ class ServeCoordinator:
 
         async def redirect_handler(request: web.Request) -> web.Response:
             nonlocal redirect_index
-            if not worker_urls:
+            if not active_ports:
                 return web.Response(text="No workers available", status=503)
-            url = worker_urls[redirect_index % len(worker_urls)]
+            port = active_ports[redirect_index % len(active_ports)]
             redirect_index += 1
             return web.Response(
                 status=307,
                 headers={
-                    "Location": url,
+                    "Location": f"http://{local_ip}:{port}/",
                     "Cache-Control": "no-store",
                 },
             )

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -70,6 +70,7 @@ class ServeCoordinator:
         self._shutdown_requested = False
         self._client_connected_event = asyncio.Event()
         self._active_worker_ports: list[int] = []
+        self._run_task: asyncio.Task[int] | None = None
 
         # HTTP server
         self._http_runner: web.AppRunner | None = None
@@ -80,6 +81,8 @@ class ServeCoordinator:
 
         with suppress(NotImplementedError):
             loop.add_signal_handler(signal.SIGINT, self._handle_sigint)
+
+        self._run_task = asyncio.current_task()
 
         try:
             self._spawn_workers()
@@ -96,14 +99,21 @@ class ServeCoordinator:
         except asyncio.CancelledError:
             pass
         finally:
+            self._run_task = None
             await self._shutdown()
 
         return 0
 
     def _handle_sigint(self) -> None:
+        if self._shutdown_requested:
+            # Second Ctrl+C — force exit
+            return
         self._shutdown_requested = True
         print("\nShutting down...")  # noqa: T201
         self._client_connected_event.set()
+        # Cancel the run task to break out of blocking audio decode
+        if self._run_task is not None:
+            self._run_task.cancel()
 
     def _spawn_workers(self) -> None:
         """Spawn worker subprocesses."""

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -204,20 +204,16 @@ class ServeCoordinator:
                 break
 
     def _check_worker_health(self) -> None:
-        """Check for crashed workers."""
-        alive_count = sum(1 for p in self._processes if p.is_alive())
-
+        """Check for crashed workers - shut down if any died."""
         for i, proc in enumerate(self._processes):
             if not proc.is_alive() and i not in self._reported_crashed:
                 self._reported_crashed.add(i)
                 port = self.worker_ports[i]
-                print(f"[health] Worker {i} (port {port}) crashed")  # noqa: T201
-
-        if alive_count == 0 and self._processes:
-            print("[health] All workers have crashed, shutting down")  # noqa: T201
-            self._shutdown_requested = True
-            if self._run_task is not None:
-                self._run_task.cancel()
+                print(f"[health] Worker {i} (port {port}) crashed, shutting down")  # noqa: T201
+                self._shutdown_requested = True
+                if self._run_task is not None:
+                    self._run_task.cancel()
+                return
 
     def _log_client_stats(self) -> None:
         """Print per-worker client counts to console."""

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -199,9 +199,17 @@ class ServeCoordinator:
             except Exception:  # noqa: BLE001
                 break
 
+    def _log_client_stats(self) -> None:
+        """Print per-worker client counts to console."""
+        total = sum(self._client_counts.values())
+        parts = [f"W{wid}={count}" for wid, count in sorted(self._client_counts.items())]
+        summary = ", ".join(parts) if parts else "no workers reporting"
+        print(f"[stats] {total} clients connected ({summary})")  # noqa: T201
+
     async def _stream_audio_loop(self) -> None:
         """Decode audio and fan out PCM chunks to all workers."""
         consecutive_errors = 0
+        last_stats_time = time.monotonic()
 
         while not self._shutdown_requested:
             try:
@@ -215,6 +223,11 @@ class ServeCoordinator:
                         break  # type: ignore[unreachable]
 
                     await self._drain_status_queue()
+
+                    now = time.monotonic()
+                    if now - last_stats_time >= 30.0:
+                        self._log_client_stats()
+                        last_stats_time = now
 
                     frame_stride = (fmt.bit_depth // 8) * fmt.channels
                     sample_count = len(pcm_chunk) // frame_stride

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -31,7 +31,8 @@ from sendspin.serve.worker import worker_main
 
 logger = logging.getLogger(__name__)
 
-MAX_BUFFER_AHEAD_US = 5_000_000  # Keep at least 5s of buffer on workers
+# Keep at least 5s of buffer on workers/connected clients
+MAX_BUFFER_AHEAD_US = 5_000_000
 
 
 class ServeCoordinator:
@@ -65,7 +66,6 @@ class ServeCoordinator:
         # State
         self._client_counts: dict[int, int] = {}
         self._shutdown_requested = False
-        self._client_connected_event = asyncio.Event()
         self._run_task: asyncio.Task[int] | None = None
         self._reported_crashed: set[int] = set()
 
@@ -109,7 +109,6 @@ class ServeCoordinator:
             return
         self._shutdown_requested = True
         print("\nShutting down...")  # noqa: T201
-        self._client_connected_event.set()
         # Cancel the run task to break out of blocking audio decode
         if self._run_task is not None:
             self._run_task.cancel()

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import multiprocessing as mp
+import queue as _queue
 import signal
 import time
 from contextlib import suppress
@@ -155,17 +156,20 @@ class ServeCoordinator:
         """Process status messages until at least one client connects or shutdown."""
         loop = asyncio.get_running_loop()
 
-        while not self._shutdown_requested:
+        def _get_with_timeout() -> object | None:
             try:
-                msg = await asyncio.wait_for(
-                    loop.run_in_executor(None, self._status_queue.get),
-                    timeout=0.5,
-                )
-                self._handle_status_message(msg)
-                if isinstance(msg, WorkerClientConnected):
-                    return
-            except TimeoutError:
+                result: object = self._status_queue.get(timeout=0.5)
+            except _queue.Empty:
+                return None
+            return result
+
+        while not self._shutdown_requested:
+            msg = await loop.run_in_executor(None, _get_with_timeout)
+            if msg is None:
                 continue
+            self._handle_status_message(msg)
+            if isinstance(msg, WorkerClientConnected):
+                return
 
     def _handle_status_message(self, msg: object) -> None:
         """Handle a single status message from a worker."""

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -53,7 +53,7 @@ class ServeCoordinator:
         self.name = name
         self.workers = workers
         self.log_level = log_level
-        self.worker_ports = [port + 1 + i for i in range(workers)]
+        self.worker_ports = [port + i for i in range(workers)]
 
         # IPC
         self._ctx = mp.get_context("spawn")

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -273,7 +273,10 @@ class ServeCoordinator:
 
         async def status_handler(request: web.Request) -> web.Response:
             total = sum(client_counts.values())
-            return web.json_response({"total_clients": total})
+            return web.json_response(
+                {"total_clients": total},
+                headers={"Access-Control-Allow-Origin": "*"},
+            )
 
         app.router.add_get("/", redirect_handler)
         app.router.add_get("/api/status", status_handler)

--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -80,7 +80,10 @@ class ServeCoordinator:
 
         try:
             self._spawn_workers()
-            await self._wait_for_workers_listening()
+            ready = await self._wait_for_workers_listening()
+            if ready == 0:
+                print("Error: all workers failed to start")  # noqa: T201
+                return 1
             self._print_banner()
 
             # Wait for first client on any worker
@@ -130,12 +133,14 @@ class ServeCoordinator:
 
         logger.info("Spawned %d worker processes", self.workers)
 
-    async def _wait_for_workers_listening(self) -> None:
-        """Wait for all workers to report they are listening."""
+    async def _wait_for_workers_listening(self) -> int:
+        """Wait for all workers to report status. Returns count of healthy workers."""
         loop = asyncio.get_running_loop()
         listening_count = 0
+        error_count = 0
+        failed_workers: set[int] = set()
 
-        while listening_count < self.workers:
+        while (listening_count + error_count) < self.workers:
             msg = await loop.run_in_executor(None, self._status_queue.get)
 
             if isinstance(msg, WorkerListening):
@@ -148,8 +153,17 @@ class ServeCoordinator:
                     self.workers,
                 )
             elif isinstance(msg, WorkerError):
+                error_count += 1
+                failed_workers.add(msg.worker_id)
                 logger.error("Worker %d error during startup: %s", msg.worker_id, msg.error)
-                listening_count += 1
+
+        if failed_workers and self._audio_queues:
+            # Remove audio queues for failed workers so we don't push into dead queues
+            for wid in sorted(failed_workers, reverse=True):
+                if wid < len(self._audio_queues):
+                    self._audio_queues.pop(wid)
+
+        return listening_count
 
     async def _consume_status_until_client(self) -> None:
         """Process status messages until at least one client connects or shutdown."""

--- a/sendspin/serve/ipc.py
+++ b/sendspin/serve/ipc.py
@@ -1,0 +1,63 @@
+"""IPC message types for multi-worker serve mode.
+
+These dataclasses are sent between the coordinator (main process) and worker
+subprocesses via multiprocessing.Queue. They must be picklable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# --- Coordinator -> Worker messages (via per-worker audio queue) ---
+
+
+@dataclass
+class AudioChunk:
+    """PCM audio data with a shared timestamp for synchronized playback."""
+
+    pcm_bytes: bytes
+    sample_rate: int
+    bit_depth: int
+    channels: int
+    play_start_us: int
+
+
+@dataclass
+class Shutdown:
+    """Signal the worker to shut down gracefully."""
+
+
+# --- Worker -> Coordinator messages (via shared status queue) ---
+
+
+@dataclass
+class WorkerListening:
+    """Worker server is accepting connections."""
+
+    worker_id: int
+    port: int
+
+
+@dataclass
+class WorkerClientConnected:
+    """A client connected to this worker."""
+
+    worker_id: int
+    client_id: str
+
+
+@dataclass
+class WorkerClientCount:
+    """Updated connected client count for this worker."""
+
+    worker_id: int
+    count: int
+
+
+@dataclass
+class WorkerError:
+    """Worker encountered an error."""
+
+    worker_id: int
+    error: str

--- a/sendspin/serve/server.py
+++ b/sendspin/serve/server.py
@@ -2,6 +2,7 @@
 
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 from aiohttp import web
 from aiosendspin.server import SendspinServer
@@ -10,6 +11,10 @@ from aiosendspin.server import SendspinServer
 class SendspinPlayerServer(SendspinServer):
     """SendspinServer that serves an embedded web player at /."""
 
+    def __init__(self, *, coordinator_url: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._coordinator_url = coordinator_url
+
     def _create_web_application(self) -> web.Application:
         """Create web app with embedded player and static file serving."""
         app = super()._create_web_application()
@@ -17,11 +22,25 @@ class SendspinPlayerServer(SendspinServer):
         # Get path to web assets directory
         web_path = Path(str(files("sendspin.serve.web")))
 
-        # Serve index.html at root
-        async def index_handler(request: web.Request) -> web.FileResponse:
-            return web.FileResponse(web_path / "index.html")
+        coordinator_url = self._coordinator_url
+        server_ref = self
+
+        # Serve index.html at root, injecting coordinator URL if set
+        async def index_handler(request: web.Request) -> web.Response:
+            html = (web_path / "index.html").read_text()
+            if coordinator_url:
+                inject = (
+                    f'<script>window.__SENDSPIN_COORDINATOR_URL__ = "{coordinator_url}";</script>\n'
+                )
+                html = html.replace("</head>", f"{inject}</head>", 1)
+            return web.Response(text=html, content_type="text/html")
+
+        async def status_handler(request: web.Request) -> web.Response:
+            count = len(server_ref.connected_clients)
+            return web.json_response({"total_clients": count})
 
         app.router.add_get("/", index_handler)
+        app.router.add_get("/api/status", status_handler)
 
         # Serve other static files (css, js)
         app.router.add_static("/", web_path)

--- a/sendspin/serve/server.py
+++ b/sendspin/serve/server.py
@@ -1,6 +1,7 @@
 """Custom SendspinServer with embedded web player."""
 
 from importlib.resources import files
+from multiprocessing.sharedctypes import Synchronized
 from pathlib import Path
 from typing import Any
 
@@ -11,9 +12,9 @@ from aiosendspin.server import SendspinServer
 class SendspinPlayerServer(SendspinServer):
     """SendspinServer that serves an embedded web player at /."""
 
-    def __init__(self, *, coordinator_url: str | None = None, **kwargs: Any) -> None:
+    def __init__(self, *, total_listeners: Synchronized[int] | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._coordinator_url = coordinator_url
+        self._total_listeners = total_listeners
 
     def _create_web_application(self) -> web.Application:
         """Create web app with embedded player and static file serving."""
@@ -22,21 +23,18 @@ class SendspinPlayerServer(SendspinServer):
         # Get path to web assets directory
         web_path = Path(str(files("sendspin.serve.web")))
 
-        coordinator_url = self._coordinator_url
+        total_listeners = self._total_listeners
         server_ref = self
 
-        # Serve index.html at root, injecting coordinator URL if set
-        async def index_handler(request: web.Request) -> web.Response:
-            html = (web_path / "index.html").read_text()
-            if coordinator_url:
-                inject = (
-                    f'<script>window.__SENDSPIN_COORDINATOR_URL__ = "{coordinator_url}";</script>\n'
-                )
-                html = html.replace("</head>", f"{inject}</head>", 1)
-            return web.Response(text=html, content_type="text/html")
+        # Serve index.html at root
+        async def index_handler(request: web.Request) -> web.FileResponse:
+            return web.FileResponse(web_path / "index.html")
 
         async def status_handler(request: web.Request) -> web.Response:
-            count = len(server_ref.connected_clients)
+            if total_listeners is not None:
+                count = total_listeners.value
+            else:
+                count = len(server_ref.connected_clients)
             return web.json_response(
                 {"total_clients": count},
                 headers={"Access-Control-Allow-Origin": "*"},

--- a/sendspin/serve/server.py
+++ b/sendspin/serve/server.py
@@ -37,7 +37,10 @@ class SendspinPlayerServer(SendspinServer):
 
         async def status_handler(request: web.Request) -> web.Response:
             count = len(server_ref.connected_clients)
-            return web.json_response({"total_clients": count})
+            return web.json_response(
+                {"total_clients": count},
+                headers={"Access-Control-Allow-Origin": "*"},
+            )
 
         app.router.add_get("/", index_handler)
         app.router.add_get("/api/status", status_handler)

--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -7,6 +7,7 @@ const MAX_VOLUME = 100;
 const UI_ACTIVATION_MS = 550;
 const SYNC_UPDATE_INTERVAL_MS = 250;
 const COPY_FEEDBACK_MS = 2000;
+const LISTENER_POLL_INTERVAL_MS = 10_000;
 const START_HAPTIC_PATTERN = [18, 28, 24];
 const STOP_HAPTIC_PATTERN = [14];
 const SYNC_PLACEHOLDER = "--.- ms";
@@ -53,6 +54,8 @@ const elements = {
   shareBtn: document.getElementById("share-btn"),
   shareServerUrl: document.getElementById("share-server-url"),
   castLink: document.getElementById("cast-link"),
+  listenerCount: document.getElementById("listener-count"),
+  listenerCountValue: document.getElementById("listener-count-value"),
 };
 
 const state = {
@@ -61,6 +64,7 @@ const state = {
   isListening: false,
   isStarting: false,
   showPostAnimationLabel: false,
+  listenerPollInterval: null,
   sync: {
     currentMs: null,
     tone: "sync-idle",
@@ -581,6 +585,7 @@ async function startListening() {
   resetSyncDisplay();
   syncGraph.reset();
   syncGraph.start();
+  startListenerPolling();
   renderUiState();
 
   try {
@@ -618,6 +623,7 @@ function disconnect(reason = "shutdown") {
   elements.listenToggleBtn.disabled = false;
 
   syncGraph.stop();
+  stopListenerPolling();
   resetSyncDisplay();
   syncGraph.reset();
   renderUiState();
@@ -675,6 +681,38 @@ elements.shareBtn.addEventListener("click", async () => {
     elements.shareBtn.textContent = originalText;
   }, COPY_FEEDBACK_MS);
 });
+
+// Listener count polling
+const coordinatorUrl = window.__SENDSPIN_COORDINATOR_URL__ || serverUrl;
+
+async function updateListenerCount() {
+  try {
+    const resp = await fetch(`${coordinatorUrl}/api/status`);
+    if (resp.ok) {
+      const data = await resp.json();
+      const count = data.total_clients ?? 0;
+      elements.listenerCountValue.textContent = String(count);
+      elements.listenerCount.setAttribute("aria-hidden", String(count === 0));
+    }
+  } catch {
+    // Silently ignore - coordinator may not support this endpoint
+  }
+}
+
+function startListenerPolling() {
+  updateListenerCount();
+  state.listenerPollInterval = window.setInterval(
+    updateListenerCount,
+    LISTENER_POLL_INTERVAL_MS,
+  );
+}
+
+function stopListenerPolling() {
+  if (state.listenerPollInterval !== null) {
+    window.clearInterval(state.listenerPollInterval);
+    state.listenerPollInterval = null;
+  }
+}
 
 renderUiState();
 resetSyncDisplay();

--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -683,11 +683,9 @@ elements.shareBtn.addEventListener("click", async () => {
 });
 
 // Listener count polling
-const coordinatorUrl = window.__SENDSPIN_COORDINATOR_URL__ || serverUrl;
-
 async function updateListenerCount() {
   try {
-    const resp = await fetch(`${coordinatorUrl}/api/status`);
+    const resp = await fetch(`${serverUrl}/api/status`);
     if (resp.ok) {
       const data = await resp.json();
       const count = Math.max(data.total_clients ?? 0, 1);

--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -693,7 +693,7 @@ async function updateListenerCount() {
       elements.listenerCount.setAttribute("aria-hidden", "false");
     }
   } catch {
-    // Silently ignore - coordinator may not support this endpoint
+    // Silently ignore - server may be unavailable
   }
 }
 

--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -690,9 +690,9 @@ async function updateListenerCount() {
     const resp = await fetch(`${coordinatorUrl}/api/status`);
     if (resp.ok) {
       const data = await resp.json();
-      const count = data.total_clients ?? 0;
+      const count = Math.max(data.total_clients ?? 0, 1);
       elements.listenerCountValue.textContent = String(count);
-      elements.listenerCount.setAttribute("aria-hidden", String(count === 0));
+      elements.listenerCount.setAttribute("aria-hidden", "false");
     }
   } catch {
     // Silently ignore - coordinator may not support this endpoint
@@ -712,6 +712,7 @@ function stopListenerPolling() {
     window.clearInterval(state.listenerPollInterval);
     state.listenerPollInterval = null;
   }
+  elements.listenerCount.setAttribute("aria-hidden", "true");
 }
 
 renderUiState();

--- a/sendspin/serve/web/index.html
+++ b/sendspin/serve/web/index.html
@@ -25,7 +25,7 @@
           Start Listening
         </button>
         <div id="listener-count" class="listener-count" aria-hidden="true">
-          <span id="listener-count-value">0</span> listeners
+          <span id="listener-count-value">0</span> tuned in
         </div>
         <div id="sync-panel" class="sync-panel" aria-hidden="true">
           <div class="sync-panel-header">

--- a/sendspin/serve/web/index.html
+++ b/sendspin/serve/web/index.html
@@ -24,6 +24,9 @@
         >
           Start Listening
         </button>
+        <div id="listener-count" class="listener-count" aria-hidden="true">
+          <span id="listener-count-value">0</span> listeners
+        </div>
         <div id="sync-panel" class="sync-panel" aria-hidden="true">
           <div class="sync-panel-header">
             <span class="sync-panel-title">Synchronization</span>

--- a/sendspin/serve/web/styles.css
+++ b/sendspin/serve/web/styles.css
@@ -565,3 +565,21 @@ footer .separator {
     scroll-behavior: auto !important;
   }
 }
+
+.listener-count {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 10px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.listener-count[aria-hidden="false"] {
+  opacity: 1;
+}
+
+.listener-count span {
+  font-weight: 600;
+  color: var(--text-primary);
+}

--- a/sendspin/serve/worker.py
+++ b/sendspin/serve/worker.py
@@ -20,7 +20,7 @@ from aiosendspin.server import (
     SendspinServer,
 )
 from aiosendspin.server.audio import AudioFormat
-from aiosendspin.server.push_stream import PushStream
+from aiosendspin.server.push_stream import PushStream, StreamStoppedError
 
 from sendspin.serve.ipc import (
     AudioChunk,
@@ -82,8 +82,14 @@ class ServeWorker:
                         bit_depth=msg.bit_depth,
                         channels=msg.channels,
                     )
-                    stream.prepare_audio(msg.pcm_bytes, fmt)
-                    await stream.commit_audio(play_start_us=msg.play_start_us)
+                    try:
+                        stream.prepare_audio(msg.pcm_bytes, fmt)
+                        await stream.commit_audio(play_start_us=msg.play_start_us)
+                    except StreamStoppedError:
+                        # All clients disconnected — stream was stopped.
+                        # Clear it so we skip chunks until a new client connects
+                        # and _on_server_event creates a fresh stream.
+                        self._stream = None
 
         except Exception as e:
             logger.exception("[W%d] Worker error", self.worker_id)
@@ -95,7 +101,7 @@ class ServeWorker:
         """Start the SendspinPlayerServer on this worker's port."""
         loop = asyncio.get_running_loop()
         server_id = f"sendspin-worker-{self.worker_id}-{uuid.uuid4().hex[:8]}"
-        self._server = SendspinPlayerServer(  # type: ignore[call-arg]
+        self._server = SendspinPlayerServer(
             loop=loop,
             server_id=server_id,
             server_name=f"Sendspin Worker {self.worker_id}",

--- a/sendspin/serve/worker.py
+++ b/sendspin/serve/worker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import multiprocessing as mp
+from multiprocessing.sharedctypes import Synchronized
 import uuid
 from contextlib import suppress
 
@@ -46,13 +47,13 @@ class ServeWorker:
         port: int,
         audio_queue: mp.Queue,  # type: ignore[type-arg]
         status_queue: mp.Queue,  # type: ignore[type-arg]
-        coordinator_url: str,
+        total_listeners: Synchronized[int],
     ) -> None:
         self.worker_id = worker_id
         self.port = port
         self._audio_queue = audio_queue
         self._status_queue = status_queue
-        self._coordinator_url = coordinator_url
+        self._total_listeners = total_listeners
         self._server: SendspinPlayerServer | None = None
         self._active_group: SendspinGroup | None = None
         self._stream: PushStream | None = None
@@ -105,7 +106,7 @@ class ServeWorker:
             loop=loop,
             server_id=server_id,
             server_name=f"Sendspin Worker {self.worker_id}",
-            coordinator_url=self._coordinator_url,
+            total_listeners=self._total_listeners,
         )
         self._server.add_event_listener(self._on_server_event)
         await self._server.start_server(
@@ -165,7 +166,7 @@ def worker_main(
     port: int,
     audio_queue: mp.Queue,  # type: ignore[type-arg]
     status_queue: mp.Queue,  # type: ignore[type-arg]
-    coordinator_url: str,
+    total_listeners: Synchronized[int],
     log_level: str,
 ) -> None:
     """Entry point for the worker subprocess."""
@@ -178,6 +179,6 @@ def worker_main(
         port=port,
         audio_queue=audio_queue,
         status_queue=status_queue,
-        coordinator_url=coordinator_url,
+        total_listeners=total_listeners,
     )
     asyncio.run(worker.run())

--- a/sendspin/serve/worker.py
+++ b/sendspin/serve/worker.py
@@ -1,0 +1,177 @@
+"""Worker subprocess for multi-worker serve mode.
+
+Each worker runs a SendspinPlayerServer on its assigned port, groups incoming
+clients, and receives PCM chunks from the coordinator via a multiprocessing Queue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing as mp
+import uuid
+from contextlib import suppress
+
+from aiosendspin.server import (
+    ClientAddedEvent,
+    ClientRemovedEvent,
+    SendspinEvent,
+    SendspinGroup,
+    SendspinServer,
+)
+from aiosendspin.server.audio import AudioFormat
+from aiosendspin.server.push_stream import PushStream
+
+from sendspin.serve.ipc import (
+    AudioChunk,
+    Shutdown,
+    WorkerClientConnected,
+    WorkerClientCount,
+    WorkerError,
+    WorkerListening,
+)
+from sendspin.serve.server import SendspinPlayerServer
+from sendspin.utils import create_task
+
+logger = logging.getLogger(__name__)
+
+
+class ServeWorker:
+    """A single server worker running in a subprocess."""
+
+    def __init__(
+        self,
+        *,
+        worker_id: int,
+        port: int,
+        audio_queue: mp.Queue,  # type: ignore[type-arg]
+        status_queue: mp.Queue,  # type: ignore[type-arg]
+        coordinator_url: str,
+    ) -> None:
+        self.worker_id = worker_id
+        self.port = port
+        self._audio_queue = audio_queue
+        self._status_queue = status_queue
+        self._coordinator_url = coordinator_url
+        self._server: SendspinPlayerServer | None = None
+        self._active_group: SendspinGroup | None = None
+        self._stream: PushStream | None = None
+
+    async def run(self) -> None:
+        """Main worker loop: start server, consume audio queue."""
+        loop = asyncio.get_running_loop()
+
+        try:
+            await self._start_server()
+            self._status_queue.put(WorkerListening(worker_id=self.worker_id, port=self.port))
+
+            # Consume audio chunks from coordinator
+            while True:
+                msg = await loop.run_in_executor(None, self._audio_queue.get)
+
+                if isinstance(msg, Shutdown):
+                    logger.info("[W%d] Shutdown received", self.worker_id)
+                    break
+
+                if isinstance(msg, AudioChunk):
+                    stream = self._get_stream()
+                    if stream is None:
+                        continue
+                    fmt = AudioFormat(
+                        sample_rate=msg.sample_rate,
+                        bit_depth=msg.bit_depth,
+                        channels=msg.channels,
+                    )
+                    stream.prepare_audio(msg.pcm_bytes, fmt)
+                    await stream.commit_audio(play_start_us=msg.play_start_us)
+
+        except Exception as e:
+            logger.exception("[W%d] Worker error", self.worker_id)
+            self._status_queue.put(WorkerError(worker_id=self.worker_id, error=str(e)))
+        finally:
+            await self._shutdown_server()
+
+    async def _start_server(self) -> None:
+        """Start the SendspinPlayerServer on this worker's port."""
+        loop = asyncio.get_running_loop()
+        server_id = f"sendspin-worker-{self.worker_id}-{uuid.uuid4().hex[:8]}"
+        self._server = SendspinPlayerServer(  # type: ignore[call-arg]
+            loop=loop,
+            server_id=server_id,
+            server_name=f"Sendspin Worker {self.worker_id}",
+            coordinator_url=self._coordinator_url,
+        )
+        self._server.add_event_listener(self._on_server_event)
+        await self._server.start_server(
+            port=self.port,
+            advertise_addresses=[],
+            discover_clients=False,
+        )
+        logger.info("[W%d] Listening on port %d", self.worker_id, self.port)
+
+    def _on_server_event(self, server: SendspinServer, event: SendspinEvent) -> None:
+        """Handle client connect/disconnect events."""
+        if isinstance(event, ClientAddedEvent):
+            client = server.get_client(event.client_id)
+            if client is None:
+                return
+
+            logger.info("[W%d] Client connected: %s", self.worker_id, event.client_id)
+
+            if self._active_group is None:
+                self._active_group = client.group
+                self._stream = self._active_group.start_stream()
+            else:
+                create_task(self._active_group.add_client(client))
+
+            self._status_queue.put(
+                WorkerClientConnected(worker_id=self.worker_id, client_id=event.client_id)
+            )
+            self._report_client_count()
+
+        elif isinstance(event, ClientRemovedEvent):
+            logger.info("[W%d] Client disconnected: %s", self.worker_id, event.client_id)
+            self._report_client_count()
+
+    def _report_client_count(self) -> None:
+        """Send current client count to coordinator."""
+        if self._server is None:
+            return
+        count = len(self._server.connected_clients)
+        self._status_queue.put(WorkerClientCount(worker_id=self.worker_id, count=count))
+
+    def _get_stream(self) -> PushStream | None:
+        """Get the active PushStream, or None if no clients are connected."""
+        return self._stream
+
+    async def _shutdown_server(self) -> None:
+        """Gracefully shut down the server."""
+        if self._stream is not None:
+            with suppress(Exception):
+                self._stream.stop()
+        if self._server is not None:
+            with suppress(Exception):
+                await self._server.close()
+
+
+def worker_main(
+    worker_id: int,
+    port: int,
+    audio_queue: mp.Queue,  # type: ignore[type-arg]
+    status_queue: mp.Queue,  # type: ignore[type-arg]
+    coordinator_url: str,
+    log_level: str,
+) -> None:
+    """Entry point for the worker subprocess."""
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.INFO),
+        format=f"%(asctime)s %(levelname)s [W{worker_id}] %(message)s",
+    )
+    worker = ServeWorker(
+        worker_id=worker_id,
+        port=port,
+        audio_queue=audio_queue,
+        status_queue=status_queue,
+        coordinator_url=coordinator_url,
+    )
+    asyncio.run(worker.run())

--- a/sendspin/serve/worker.py
+++ b/sendspin/serve/worker.py
@@ -138,6 +138,15 @@ class ServeWorker:
 
         elif isinstance(event, ClientRemovedEvent):
             logger.info("[W%d] Client disconnected: %s", self.worker_id, event.client_id)
+            # If no clients remain, tear down so the next client starts fresh
+            if self._active_group is not None and not [
+                c for c in self._active_group.clients if c.client_id != event.client_id
+            ]:
+                if self._stream is not None:
+                    with suppress(Exception):
+                        self._stream.stop()
+                    self._stream = None
+                self._active_group = None
             self._report_client_count()
 
     def _report_client_count(self) -> None:

--- a/sendspin/serve/worker.py
+++ b/sendspin/serve/worker.py
@@ -88,9 +88,9 @@ class ServeWorker:
                         await stream.commit_audio(play_start_us=msg.play_start_us)
                     except StreamStoppedError:
                         # All clients disconnected — stream was stopped.
-                        # Clear it so we skip chunks until a new client connects
-                        # and _on_server_event creates a fresh stream.
+                        # Clear both so the next client starts a fresh group/stream.
                         self._stream = None
+                        self._active_group = None
 
         except Exception as e:
             logger.exception("[W%d] Worker error", self.worker_id)

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -1,0 +1,103 @@
+"""Tests for ServeCoordinator."""
+
+from __future__ import annotations
+
+
+import pytest
+from aiohttp import ClientSession
+
+from sendspin.serve.coordinator import ServeCoordinator
+
+
+@pytest.fixture
+def coordinator() -> ServeCoordinator:
+    return ServeCoordinator(
+        source="http://example.com/test.mp3",
+        source_format=None,
+        port=18927,
+        name="Test Server",
+        workers=2,
+        log_level="WARNING",
+    )
+
+
+def test_coordinator_init(coordinator: ServeCoordinator) -> None:
+    assert coordinator.port == 18927
+    assert coordinator.workers == 2
+    assert coordinator.worker_ports == [18928, 18929]
+
+
+def test_coordinator_worker_ports_calculation() -> None:
+    coord = ServeCoordinator(
+        source="test.mp3",
+        source_format=None,
+        port=9000,
+        name="Test",
+        workers=4,
+        log_level="WARNING",
+    )
+    assert coord.worker_ports == [9001, 9002, 9003, 9004]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_round_robin_redirect() -> None:
+    """The HTTP server should 307-redirect round-robin to worker ports."""
+    coord = ServeCoordinator(
+        source="test.mp3",
+        source_format=None,
+        port=18950,
+        name="Test",
+        workers=2,
+        log_level="WARNING",
+    )
+
+    await coord._start_http_server()
+
+    try:
+        async with ClientSession() as session:
+            # First request -> worker 0 (port 18951)
+            async with session.get("http://127.0.0.1:18950/", allow_redirects=False) as resp:
+                assert resp.status == 307
+                location = resp.headers["Location"]
+                assert ":18951/" in location
+
+            # Second request -> worker 1 (port 18952)
+            async with session.get("http://127.0.0.1:18950/", allow_redirects=False) as resp:
+                assert resp.status == 307
+                location = resp.headers["Location"]
+                assert ":18952/" in location
+
+            # Third request -> back to worker 0
+            async with session.get("http://127.0.0.1:18950/", allow_redirects=False) as resp:
+                assert resp.status == 307
+                location = resp.headers["Location"]
+                assert ":18951/" in location
+    finally:
+        await coord._stop_http_server()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_status_endpoint() -> None:
+    """GET /api/status should return aggregated client count."""
+    coord = ServeCoordinator(
+        source="test.mp3",
+        source_format=None,
+        port=18951,
+        name="Test",
+        workers=2,
+        log_level="WARNING",
+    )
+
+    # Simulate client counts from 2 workers
+    coord._client_counts = {0: 5, 1: 3}
+
+    await coord._start_http_server()
+
+    try:
+        async with ClientSession() as session:
+            async with session.get("http://127.0.0.1:18951/api/status") as resp:
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"total_clients": 8}
+    finally:
+        await coord._stop_http_server()

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -51,6 +51,9 @@ async def test_coordinator_round_robin_redirect() -> None:
         log_level="WARNING",
     )
 
+    # Simulate workers having reported listening
+    coord._active_worker_ports = [18951, 18952]
+
     await coord._start_http_server()
 
     try:

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pytest
 
 from sendspin.serve.coordinator import ServeCoordinator
-from sendspin.serve.ipc import WorkerClientCount
+from sendspin.serve.ipc import WorkerClientCount, WorkerError, WorkerListening
 
 
 @pytest.fixture
@@ -48,3 +48,23 @@ def test_coordinator_updates_total_listeners(coordinator: ServeCoordinator) -> N
     # Worker 0 loses a client
     coordinator._handle_status_message(WorkerClientCount(worker_id=0, count=4))
     assert coordinator._total_listeners.value == 7
+
+
+@pytest.mark.asyncio
+async def test_wait_for_workers_fails_when_all_error(coordinator: ServeCoordinator) -> None:
+    """If all workers report errors, _wait_for_workers_listening should return 0."""
+    coordinator._status_queue.put(WorkerError(worker_id=0, error="bind failed"))
+    coordinator._status_queue.put(WorkerError(worker_id=1, error="bind failed"))
+
+    ready = await coordinator._wait_for_workers_listening()
+    assert ready == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_workers_partial_success(coordinator: ServeCoordinator) -> None:
+    """If some workers succeed and some fail, return the success count."""
+    coordinator._status_queue.put(WorkerListening(worker_id=0, port=18927))
+    coordinator._status_queue.put(WorkerError(worker_id=1, error="bind failed"))
+
+    ready = await coordinator._wait_for_workers_listening()
+    assert ready == 1

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -24,7 +24,7 @@ def coordinator() -> ServeCoordinator:
 def test_coordinator_init(coordinator: ServeCoordinator) -> None:
     assert coordinator.port == 18927
     assert coordinator.workers == 2
-    assert coordinator.worker_ports == [18928, 18929]
+    assert coordinator.worker_ports == [18927, 18928]
 
 
 def test_coordinator_worker_ports_calculation() -> None:
@@ -36,7 +36,7 @@ def test_coordinator_worker_ports_calculation() -> None:
         workers=4,
         log_level="WARNING",
     )
-    assert coord.worker_ports == [9001, 9002, 9003, 9004]
+    assert coord.worker_ports == [9000, 9001, 9002, 9003]
 
 
 def test_coordinator_updates_total_listeners(coordinator: ServeCoordinator) -> None:

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 
 import pytest
-from aiohttp import ClientSession
 
 from sendspin.serve.coordinator import ServeCoordinator
+from sendspin.serve.ipc import WorkerClientCount
 
 
 @pytest.fixture
@@ -39,68 +39,12 @@ def test_coordinator_worker_ports_calculation() -> None:
     assert coord.worker_ports == [9001, 9002, 9003, 9004]
 
 
-@pytest.mark.asyncio
-async def test_coordinator_round_robin_redirect() -> None:
-    """The HTTP server should 307-redirect round-robin to worker ports."""
-    coord = ServeCoordinator(
-        source="test.mp3",
-        source_format=None,
-        port=18950,
-        name="Test",
-        workers=2,
-        log_level="WARNING",
-    )
+def test_coordinator_updates_total_listeners(coordinator: ServeCoordinator) -> None:
+    """_handle_status_message should update shared _total_listeners value."""
+    coordinator._handle_status_message(WorkerClientCount(worker_id=0, count=5))
+    coordinator._handle_status_message(WorkerClientCount(worker_id=1, count=3))
+    assert coordinator._total_listeners.value == 8
 
-    # Simulate workers having reported listening
-    coord._active_worker_ports = [18951, 18952]
-
-    await coord._start_http_server()
-
-    try:
-        async with ClientSession() as session:
-            # First request -> worker 0 (port 18951)
-            async with session.get("http://127.0.0.1:18950/", allow_redirects=False) as resp:
-                assert resp.status == 307
-                location = resp.headers["Location"]
-                assert ":18951/" in location
-
-            # Second request -> worker 1 (port 18952)
-            async with session.get("http://127.0.0.1:18950/", allow_redirects=False) as resp:
-                assert resp.status == 307
-                location = resp.headers["Location"]
-                assert ":18952/" in location
-
-            # Third request -> back to worker 0
-            async with session.get("http://127.0.0.1:18950/", allow_redirects=False) as resp:
-                assert resp.status == 307
-                location = resp.headers["Location"]
-                assert ":18951/" in location
-    finally:
-        await coord._stop_http_server()
-
-
-@pytest.mark.asyncio
-async def test_coordinator_status_endpoint() -> None:
-    """GET /api/status should return aggregated client count."""
-    coord = ServeCoordinator(
-        source="test.mp3",
-        source_format=None,
-        port=18951,
-        name="Test",
-        workers=2,
-        log_level="WARNING",
-    )
-
-    # Simulate client counts from 2 workers
-    coord._client_counts = {0: 5, 1: 3}
-
-    await coord._start_http_server()
-
-    try:
-        async with ClientSession() as session:
-            async with session.get("http://127.0.0.1:18951/api/status") as resp:
-                assert resp.status == 200
-                data = await resp.json()
-                assert data == {"total_clients": 8}
-    finally:
-        await coord._stop_http_server()
+    # Worker 0 loses a client
+    coordinator._handle_status_message(WorkerClientCount(worker_id=0, count=4))
+    assert coordinator._total_listeners.value == 7

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from sendspin.serve.coordinator import ServeCoordinator
@@ -68,3 +70,37 @@ async def test_wait_for_workers_partial_success(coordinator: ServeCoordinator) -
 
     ready = await coordinator._wait_for_workers_listening()
     assert ready == 1
+    assert coordinator._failed_workers == {1}
+
+
+def test_check_worker_health_ignores_startup_failed_workers(coordinator: ServeCoordinator) -> None:
+    """Startup-failed workers should not trigger later crash shutdown."""
+    healthy_proc = MagicMock()
+    healthy_proc.is_alive.return_value = True
+    failed_proc = MagicMock()
+    failed_proc.is_alive.return_value = False
+
+    coordinator._processes = [healthy_proc, failed_proc]
+    coordinator._failed_workers = {1}
+    coordinator._reported_crashed = {1}
+
+    coordinator._check_worker_health()
+
+    assert coordinator._shutdown_requested is False
+
+
+def test_check_worker_health_shuts_down_on_unexpected_worker_crash(
+    coordinator: ServeCoordinator,
+) -> None:
+    """A healthy worker dying after startup should still shut the coordinator down."""
+    healthy_proc = MagicMock()
+    healthy_proc.is_alive.return_value = False
+    other_proc = MagicMock()
+    other_proc.is_alive.return_value = True
+
+    coordinator._processes = [healthy_proc, other_proc]
+
+    coordinator._check_worker_health()
+
+    assert coordinator._shutdown_requested is True
+    assert coordinator._reported_crashed == {0}

--- a/tests/serve/test_integration.py
+++ b/tests/serve/test_integration.py
@@ -1,0 +1,45 @@
+"""Integration tests for multi-worker serve mode."""
+
+from __future__ import annotations
+
+
+import pytest
+from aiohttp import ClientSession
+
+from sendspin.serve.coordinator import ServeCoordinator
+
+
+@pytest.mark.asyncio
+async def test_multi_worker_http_redirect_and_status() -> None:
+    """Start coordinator with 2 workers, verify redirect and status endpoint."""
+    coordinator = ServeCoordinator(
+        source="http://retro.dancewave.online/retrodance.mp3",
+        source_format=None,
+        port=19800,
+        name="Integration Test",
+        workers=2,
+        log_level="WARNING",
+    )
+
+    # Start workers and HTTP server only (don't start audio streaming)
+    coordinator._spawn_workers()
+
+    try:
+        await coordinator._wait_for_workers_listening()
+        await coordinator._start_http_server()
+
+        async with ClientSession() as session:
+            # Test round-robin redirect
+            async with session.get("http://127.0.0.1:19800/", allow_redirects=False) as resp:
+                assert resp.status == 307
+                location = resp.headers["Location"]
+                assert ":19801/" in location or ":19802/" in location
+
+            # Test status endpoint (0 clients initially)
+            async with session.get("http://127.0.0.1:19800/api/status") as resp:
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["total_clients"] == 0
+
+    finally:
+        await coordinator._shutdown()

--- a/tests/serve/test_integration.py
+++ b/tests/serve/test_integration.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 import pytest
 from aiohttp import ClientSession
 
@@ -10,8 +9,8 @@ from sendspin.serve.coordinator import ServeCoordinator
 
 
 @pytest.mark.asyncio
-async def test_multi_worker_http_redirect_and_status() -> None:
-    """Start coordinator with 2 workers, verify redirect and status endpoint."""
+async def test_multi_worker_starts_and_serves_status() -> None:
+    """Start coordinator with 2 workers, verify worker /api/status returns shared count."""
     coordinator = ServeCoordinator(
         source="http://retro.dancewave.online/retrodance.mp3",
         source_format=None,
@@ -21,25 +20,18 @@ async def test_multi_worker_http_redirect_and_status() -> None:
         log_level="WARNING",
     )
 
-    # Start workers and HTTP server only (don't start audio streaming)
     coordinator._spawn_workers()
 
     try:
         await coordinator._wait_for_workers_listening()
-        await coordinator._start_http_server()
 
         async with ClientSession() as session:
-            # Test round-robin redirect
-            async with session.get("http://127.0.0.1:19800/", allow_redirects=False) as resp:
-                assert resp.status == 307
-                location = resp.headers["Location"]
-                assert ":19801/" in location or ":19802/" in location
-
-            # Test status endpoint (0 clients initially)
-            async with session.get("http://127.0.0.1:19800/api/status") as resp:
-                assert resp.status == 200
-                data = await resp.json()
-                assert data["total_clients"] == 0
+            # Each worker should serve /api/status with the shared count (0 initially)
+            for port in coordinator.worker_ports:
+                async with session.get(f"http://127.0.0.1:{port}/api/status") as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data["total_clients"] == 0
 
     finally:
         await coordinator._shutdown()

--- a/tests/serve/test_ipc.py
+++ b/tests/serve/test_ipc.py
@@ -1,0 +1,64 @@
+"""Tests for IPC message types."""
+
+from __future__ import annotations
+
+import pickle
+
+from sendspin.serve.ipc import (
+    AudioChunk,
+    Shutdown,
+    WorkerClientConnected,
+    WorkerClientCount,
+    WorkerError,
+    WorkerListening,
+)
+
+
+def test_audio_chunk_picklable() -> None:
+    msg = AudioChunk(
+        pcm_bytes=b"\x00" * 100,
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        play_start_us=1_000_000,
+    )
+    restored = pickle.loads(pickle.dumps(msg))
+    assert restored.pcm_bytes == msg.pcm_bytes
+    assert restored.sample_rate == msg.sample_rate
+    assert restored.bit_depth == msg.bit_depth
+    assert restored.channels == msg.channels
+    assert restored.play_start_us == msg.play_start_us
+
+
+def test_shutdown_picklable() -> None:
+    msg = Shutdown()
+    restored = pickle.loads(pickle.dumps(msg))
+    assert isinstance(restored, Shutdown)
+
+
+def test_worker_listening_picklable() -> None:
+    msg = WorkerListening(worker_id=0, port=8928)
+    restored = pickle.loads(pickle.dumps(msg))
+    assert restored.worker_id == 0
+    assert restored.port == 8928
+
+
+def test_worker_client_connected_picklable() -> None:
+    msg = WorkerClientConnected(worker_id=1, client_id="test-001")
+    restored = pickle.loads(pickle.dumps(msg))
+    assert restored.worker_id == 1
+    assert restored.client_id == "test-001"
+
+
+def test_worker_client_count_picklable() -> None:
+    msg = WorkerClientCount(worker_id=2, count=42)
+    restored = pickle.loads(pickle.dumps(msg))
+    assert restored.worker_id == 2
+    assert restored.count == 42
+
+
+def test_worker_error_picklable() -> None:
+    msg = WorkerError(worker_id=0, error="something broke")
+    restored = pickle.loads(pickle.dumps(msg))
+    assert restored.worker_id == 0
+    assert restored.error == "something broke"

--- a/tests/serve/test_worker.py
+++ b/tests/serve/test_worker.py
@@ -26,16 +26,22 @@ def status_queue(mp_context: mp.context.SpawnContext) -> mp.Queue:
     return mp_context.Queue()
 
 
+@pytest.fixture
+def total_listeners(mp_context: mp.context.SpawnContext) -> mp.Value:
+    return mp_context.Value("i", 0)
+
+
 def test_worker_init(
     audio_queue: mp.Queue,
     status_queue: mp.Queue,
+    total_listeners: mp.Value,
 ) -> None:
     worker = ServeWorker(
         worker_id=0,
         port=8928,
         audio_queue=audio_queue,
         status_queue=status_queue,
-        coordinator_url="http://192.168.1.5:8927",
+        total_listeners=total_listeners,
     )
     assert worker.worker_id == 0
     assert worker.port == 8928
@@ -45,6 +51,7 @@ def test_worker_init(
 async def test_worker_signals_listening_on_start(
     audio_queue: mp.Queue,
     status_queue: mp.Queue,
+    total_listeners: mp.Value,
 ) -> None:
     """Worker should put WorkerListening on the status queue after starting."""
     worker = ServeWorker(
@@ -52,7 +59,7 @@ async def test_worker_signals_listening_on_start(
         port=8928,
         audio_queue=audio_queue,
         status_queue=status_queue,
-        coordinator_url="http://192.168.1.5:8927",
+        total_listeners=total_listeners,
     )
 
     # Put a Shutdown immediately so the worker exits after starting
@@ -71,6 +78,7 @@ async def test_worker_signals_listening_on_start(
 async def test_worker_processes_audio_chunk(
     audio_queue: mp.Queue,
     status_queue: mp.Queue,
+    total_listeners: mp.Value,
 ) -> None:
     """Worker should call prepare_audio/commit_audio for each AudioChunk."""
     worker = ServeWorker(
@@ -78,7 +86,7 @@ async def test_worker_processes_audio_chunk(
         port=8928,
         audio_queue=audio_queue,
         status_queue=status_queue,
-        coordinator_url="http://192.168.1.5:8927",
+        total_listeners=total_listeners,
     )
 
     chunk = AudioChunk(

--- a/tests/serve/test_worker.py
+++ b/tests/serve/test_worker.py
@@ -111,3 +111,43 @@ async def test_worker_processes_audio_chunk(
 
     mock_stream.prepare_audio.assert_called_once()
     mock_stream.commit_audio.assert_called_once_with(play_start_us=1_000_000)
+
+
+def test_worker_clears_group_when_last_client_disconnects(
+    audio_queue: mp.Queue,
+    status_queue: mp.Queue,
+    total_listeners: mp.Value,
+) -> None:
+    """When the last client disconnects, active_group and stream should be cleared."""
+    worker = ServeWorker(
+        worker_id=0,
+        port=8928,
+        audio_queue=audio_queue,
+        status_queue=status_queue,
+        total_listeners=total_listeners,
+    )
+
+    # Set up a mock group with one client that will be "removed"
+    mock_stream = MagicMock()
+    mock_stream.stop = MagicMock()
+    mock_group = MagicMock()
+    mock_group.clients = []  # Empty after removal
+
+    worker._active_group = mock_group
+    worker._stream = mock_stream
+
+    # Create a mock server with no connected clients
+    mock_server = MagicMock()
+    mock_server.connected_clients = {}
+    worker._server = mock_server
+
+    # Simulate ClientRemovedEvent
+    from aiosendspin.server import ClientRemovedEvent
+
+    event = ClientRemovedEvent(client_id="test-client")
+    worker._on_server_event(mock_server, event)
+
+    # Group and stream should be cleared
+    assert worker._active_group is None
+    assert worker._stream is None
+    mock_stream.stop.assert_called_once()

--- a/tests/serve/test_worker.py
+++ b/tests/serve/test_worker.py
@@ -1,0 +1,105 @@
+"""Tests for ServeWorker."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sendspin.serve.ipc import AudioChunk, Shutdown, WorkerListening
+from sendspin.serve.worker import ServeWorker
+
+
+@pytest.fixture
+def mp_context() -> mp.context.SpawnContext:
+    return mp.get_context("spawn")
+
+
+@pytest.fixture
+def audio_queue(mp_context: mp.context.SpawnContext) -> mp.Queue:
+    return mp_context.Queue()
+
+
+@pytest.fixture
+def status_queue(mp_context: mp.context.SpawnContext) -> mp.Queue:
+    return mp_context.Queue()
+
+
+def test_worker_init(
+    audio_queue: mp.Queue,
+    status_queue: mp.Queue,
+) -> None:
+    worker = ServeWorker(
+        worker_id=0,
+        port=8928,
+        audio_queue=audio_queue,
+        status_queue=status_queue,
+        coordinator_url="http://192.168.1.5:8927",
+    )
+    assert worker.worker_id == 0
+    assert worker.port == 8928
+
+
+@pytest.mark.asyncio
+async def test_worker_signals_listening_on_start(
+    audio_queue: mp.Queue,
+    status_queue: mp.Queue,
+) -> None:
+    """Worker should put WorkerListening on the status queue after starting."""
+    worker = ServeWorker(
+        worker_id=0,
+        port=8928,
+        audio_queue=audio_queue,
+        status_queue=status_queue,
+        coordinator_url="http://192.168.1.5:8927",
+    )
+
+    # Put a Shutdown immediately so the worker exits after starting
+    audio_queue.put(Shutdown())
+
+    with patch.object(worker, "_start_server", new_callable=AsyncMock):
+        await worker.run()
+
+    msg = status_queue.get(timeout=1)
+    assert isinstance(msg, WorkerListening)
+    assert msg.worker_id == 0
+    assert msg.port == 8928
+
+
+@pytest.mark.asyncio
+async def test_worker_processes_audio_chunk(
+    audio_queue: mp.Queue,
+    status_queue: mp.Queue,
+) -> None:
+    """Worker should call prepare_audio/commit_audio for each AudioChunk."""
+    worker = ServeWorker(
+        worker_id=0,
+        port=8928,
+        audio_queue=audio_queue,
+        status_queue=status_queue,
+        coordinator_url="http://192.168.1.5:8927",
+    )
+
+    chunk = AudioChunk(
+        pcm_bytes=b"\x00" * 100,
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        play_start_us=1_000_000,
+    )
+    audio_queue.put(chunk)
+    audio_queue.put(Shutdown())
+
+    mock_stream = MagicMock()
+    mock_stream.prepare_audio = MagicMock()
+    mock_stream.commit_audio = AsyncMock(return_value=1_000_000)
+
+    with (
+        patch.object(worker, "_start_server", new_callable=AsyncMock),
+        patch.object(worker, "_get_stream", return_value=mock_stream),
+    ):
+        await worker.run()
+
+    mock_stream.prepare_audio.assert_called_once()
+    mock_stream.commit_audio.assert_called_once_with(play_start_us=1_000_000)


### PR DESCRIPTION
## Summary

This PR adds multi-worker support to `sendspin serve` so multiple worker processes can accept Sendspin Party listeners while sharing the
same decoded audio timeline.

It introduces a coordinator/worker architecture where:
- the coordinator decodes the source once and fans out timestamped PCM chunks
- each worker runs its own HTTP/WebSocket server and serves the embedded web player
- the web UI can report total connected listeners across workers

## Changes

- add `--workers` to `sendspin serve`
- add multi-worker serve coordinator/worker implementation
- add IPC message types for coordinator/worker communication
- add `/api/status` endpoint for total listener count
- update the embedded web player to poll and display listener count
- reject `--client` when used with multi-worker mode
- pause decoding when all listeners disconnect in multi-worker mode
- handle worker startup failures and unexpected worker crashes correctly
- fix worker reconnect behavior after the last client disconnects
- document multi-worker mode in `README.md`

## Notes

- Multi-worker mode runs one HTTP/WebSocket server per worker
- place a reverse proxy/load balancer in front of the worker ports
- `--client` remains supported in single-worker serve mode only