### PR TITLE
Fix playback stop on server-initiated reconnection

### DIFF
--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -448,7 +448,8 @@ class AudioStreamHandler:
         """Handle incoming audio chunks by enqueueing them to the sync worker."""
         worker = self._audio_worker
         if worker is None or not worker.is_running():
-            raise RuntimeError("Audio worker is not running")
+            logger.debug("Audio chunk dropped: worker not running")
+            return
 
         pcm_format = fmt.pcm_format
         if self._current_format != fmt:

--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -322,7 +322,6 @@ class AudioStreamHandler:
         self._client_unsubscribers: list[Callable[[], None]] = []
 
         self._volume_controller: VolumeController | None = volume_controller
-        self._chunks_dropping = False
 
     @property
     def volume(self) -> int:
@@ -449,11 +448,8 @@ class AudioStreamHandler:
         """Handle incoming audio chunks by enqueueing them to the sync worker."""
         worker = self._audio_worker
         if worker is None or not worker.is_running():
-            if not self._chunks_dropping:
-                logger.debug("Audio chunks dropping: worker not running")
-                self._chunks_dropping = True
+            logger.debug("Audio chunk dropped: worker not running")
             return
-        self._chunks_dropping = False
 
         pcm_format = fmt.pcm_format
         if self._current_format != fmt:

--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -322,6 +322,7 @@ class AudioStreamHandler:
         self._client_unsubscribers: list[Callable[[], None]] = []
 
         self._volume_controller: VolumeController | None = volume_controller
+        self._chunks_dropping = False
 
     @property
     def volume(self) -> int:
@@ -448,8 +449,11 @@ class AudioStreamHandler:
         """Handle incoming audio chunks by enqueueing them to the sync worker."""
         worker = self._audio_worker
         if worker is None or not worker.is_running():
-            logger.debug("Audio chunk dropped: worker not running")
+            if not self._chunks_dropping:
+                logger.debug("Audio chunks dropping: worker not running")
+                self._chunks_dropping = True
             return
+        self._chunks_dropping = False
 
         pcm_format = fmt.pcm_format
         if self._current_format != fmt:

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -11,15 +11,10 @@ from typing import TYPE_CHECKING
 
 from aiohttp import ClientError, web
 from aiosendspin.client import ClientListener, SendspinClient
-from aiosendspin.models.core import (
-    ClientGoodbyeMessage,
-    ClientGoodbyePayload,
-    ServerCommandPayload,
-)
+from aiosendspin.models.core import ServerCommandPayload
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin_mpris import MPRIS_AVAILABLE, SendspinMpris
 from aiosendspin.models.types import (
-    GoodbyeReason,
     PlayerCommand,
     Roles,
 )
@@ -226,23 +221,28 @@ class SendspinDaemon:
         # Lock ensures we wait for any in-progress handshake to complete
         # before disconnecting the previous server
         async with self._connection_lock:
-            # Clean up any previous client
-            if self._client is not None:
+            old_client = self._client
+
+            # Handshake the new connection BEFORE tearing down the old one.
+            # This ensures the server always sees at least one active client
+            # in the group, preventing it from stopping playback during
+            # a same-server reconnection.
+            client = self._create_client(self._static_delay_ms)
+
+            try:
+                await client.attach_websocket(ws)
+            except TimeoutError:
+                logger.warning("Handshake with server timed out")
+                return
+            except Exception:
+                logger.exception("Error during server handshake")
+                return
+
+            # Handshake succeeded — switch over from old to new connection.
+            if old_client is not None:
                 logger.info("Disconnecting from previous server")
                 await self._handle_disconnect()
-                if self._client.connected:
-                    try:
-                        await self._client._send_message(  # noqa: SLF001
-                            ClientGoodbyeMessage(
-                                payload=ClientGoodbyePayload(reason=GoodbyeReason.ANOTHER_SERVER)
-                            ).to_json()
-                        )
-                    except Exception:
-                        logger.debug("Failed to send goodbye message", exc_info=True)
-                await self._client.disconnect()
 
-            # Create a new client for this connection
-            client = self._create_client(self._static_delay_ms)
             self._client = client
             self._audio_handler.attach_client(client)
             client.add_server_command_listener(self._handle_server_command)
@@ -250,20 +250,9 @@ class SendspinDaemon:
                 self._mpris = SendspinMpris(client)
                 self._mpris.start()
 
-            try:
-                await client.attach_websocket(ws)
-            except TimeoutError:
-                logger.warning("Handshake with server timed out")
-                await self._handle_disconnect()
-                if self._client is client:
-                    self._client = None
-                return
-            except Exception:
-                logger.exception("Error during server handshake")
-                await self._handle_disconnect()
-                if self._client is client:
-                    self._client = None
-                return
+            # Close old connection after new one is fully established.
+            if old_client is not None:
+                await old_client.disconnect()
 
         # Handshake complete, release lock so new connections can proceed
         # Now wait for disconnect (outside the lock)

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -241,6 +241,7 @@ class SendspinDaemon:
             # Handshake succeeded — switch over from old to new connection.
             if old_client is not None:
                 logger.info("Disconnecting from previous server")
+                self._audio_handler.detach_client()
                 await self._handle_disconnect()
 
             self._client = client


### PR DESCRIPTION
I had what appeared to be a bit of a network 'blip', which my MA server noticed and attempted a reconnect, while my sendspin-cli instance was still under the impression that everything was fine. That actually caused my sendspin-cli to reset the connection on its side and playback to stop. After doing some digging, I figured that if the same server was reconnecting, if we swapped the order of 'tear down' and 'reconnect', then playback could continue (with a little audio hiccup, because there *was* an issue in the first place). If it's an ongoing issue, well then the server couldn't reconnect and we just stop (as the only option).


When the server reconnects to the daemon (same client_id, new websocket), the old code sent a goodbye message before handshaking the new connection. This caused the server to remove the client from its group and stop playback, requiring manual intervention to resume.

Reorder _handle_server_connection to handshake the new connection first, then tear down the old one. The server's attach_connection() atomically replaces the websocket for the same client_id, so the client never leaves the group and playback continues uninterrupted.