### PR TITLE
Allow serving existing sendspin server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Host a Sendspin party
 uvx sendspin serve --demo
 uvx sendspin serve /path/to/media.mp3
 uvx sendspin serve https://retro.dancewave.online/retrodance.mp3
+uvx sendspin serve --sendspin ws://upstream:8927/sendspin
 ```
 
 ## Installation
@@ -177,6 +178,7 @@ Settings are stored in `~/.config/sendspin/`:
 | `source` | string | serve | Default audio source (file path or URL, ffmpeg input) |
 | `source_format` | string | serve | ffmpeg container format for audio source |
 | `clients` | array | serve | Client URLs to connect to (`--client`) |
+| `sendspin` | string | serve | Upstream Sendspin server URL for bridge mode (`--sendspin`) |
 
 Settings are automatically saved when changed through the TUI. You can also edit the JSON file directly while the client is not running.
 
@@ -399,4 +401,15 @@ sendspin serve https://retro.dancewave.online/retrodance.mp3
 uvx sendspin serve /path/to/media.mp3
 # Connect to specific clients
 sendspin serve --demo --client ws://192.168.1.50:8927/sendspin --client ws://192.168.1.51:8927/sendspin
+```
+
+### Bridge Mode
+
+Use `--sendspin` to relay audio from an upstream Sendspin server. This creates a bridge that connects as a client to the upstream server and re-serves the audio to its own downstream clients. Useful for scaling to many clients by creating a fan-out topology.
+
+```bash
+# Bridge from an upstream server
+sendspin serve --sendspin ws://upstream-host:8927/sendspin
+# Bridge on a custom port
+sendspin serve --sendspin ws://upstream-host:8927/sendspin --port 8928
 ```

--- a/sendspin/cli.py
+++ b/sendspin/cli.py
@@ -303,6 +303,11 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
         help="Client URL to connect to (can be specified multiple times)",
     )
+    serve_parser.add_argument(
+        "--sendspin",
+        default=None,
+        help="Upstream Sendspin server WebSocket URL to bridge (e.g., ws://host:8927/sendspin)",
+    )
 
     # Daemon subcommand
     daemon_parser = subparsers.add_parser(
@@ -543,8 +548,16 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
     # Set up logging
     logging.basicConfig(level=getattr(logging, args.log_level))
 
-    # Determine audio source: CLI > --demo > settings
-    if args.demo:
+    # Determine audio source: --sendspin > CLI > --demo > settings
+    sendspin_url = args.sendspin or settings.sendspin
+
+    if sendspin_url:
+        if args.source or args.demo:
+            print("Error: --sendspin cannot be combined with a source or --demo")
+            return 1
+        source = None
+        print(f"Bridge mode: connecting to upstream server {sendspin_url}")
+    elif args.demo:
         source = "http://retro.dancewave.online/retrodance.mp3"
         print(f"Demo mode enabled, serving URL {source}")
     elif args.source:
@@ -553,7 +566,7 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
         source = settings.source
         print(f"Using source from settings: {source}")
     else:
-        print("Error: either provide a source or use --demo")
+        print("Error: either provide a source, use --demo, or use --sendspin")
         return 1
 
     serve_config = ServeConfig(
@@ -562,6 +575,7 @@ async def _run_serve_mode(args: argparse.Namespace) -> int:
         port=args.port,
         name=args.name,
         clients=args.clients or settings.clients,
+        sendspin_url=sendspin_url,
     )
     return await run_server(serve_config)
 

--- a/sendspin/serve/__init__.py
+++ b/sendspin/serve/__init__.py
@@ -78,11 +78,12 @@ def get_local_ip() -> str:
 class ServeConfig:
     """Configuration for the serve command."""
 
-    source: str
+    source: str | None = None
     source_format: str | None = None
     port: int = 8927
     name: str = "Sendspin Server"
     clients: list[str] | None = None
+    sendspin_url: str | None = None
 
 
 def _windows_exception_handler(loop: asyncio.AbstractEventLoop, context: dict[str, object]) -> None:
@@ -109,6 +110,84 @@ async def _stream_audio(stream: PushStream, source: AudioSource) -> None:
             await stream.sleep_to_limit_buffer(max_buffer_us=5_000_000)
     finally:
         stream.stop()
+
+
+async def _stream_from_sendspin(stream: PushStream, url: str) -> None:
+    """Bridge audio from an upstream Sendspin server into a PushStream.
+
+    Preserves upstream timing so clients across different bridges stay in
+    perfect sync.  The bridge requests a large buffer from the upstream
+    server (``buffer_capacity``) so it receives chunks well ahead of their
+    play-out time.  For each chunk it converts the upstream server timestamp
+    to the bridge's own server clock via ``compute_play_time`` and passes
+    that directly to ``commit_audio(play_start_us=...)``.  Downstream
+    clients therefore schedule playback against the same absolute moment on
+    their clocks, regardless of which bridge they are connected to.
+    """
+    from aiosendspin.client import AudioFormat as ClientAudioFormat, SendspinClient
+    from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+    from aiosendspin.models.types import AudioCodec, PlayerCommand, Roles
+    from aiosendspin.server import AudioFormat as ServerAudioFormat
+
+    client = SendspinClient(
+        client_id=f"bridge-{uuid.uuid4().hex[:8]}",
+        client_name="Sendspin Bridge",
+        roles=[Roles.PLAYER],
+        player_support=ClientHelloPlayerSupport(
+            supported_formats=[
+                SupportedAudioFormat(
+                    codec=AudioCodec.PCM,
+                    channels=2,
+                    sample_rate=48000,
+                    bit_depth=16,
+                ),
+            ],
+            buffer_capacity=32_000_000,
+            supported_commands=[PlayerCommand.VOLUME],
+        ),
+    )
+
+    chunk_queue: asyncio.Queue[tuple[int, bytes, ServerAudioFormat] | None] = asyncio.Queue()
+
+    def on_audio_chunk(
+        server_timestamp_us: int,
+        audio_data: bytes | bytearray,
+        fmt: ClientAudioFormat,
+    ) -> None:
+        pcm_format = fmt.pcm_format
+        server_fmt = ServerAudioFormat(
+            sample_rate=pcm_format.sample_rate,
+            bit_depth=pcm_format.bit_depth,
+            channels=pcm_format.channels,
+        )
+        chunk_queue.put_nowait((server_timestamp_us, bytes(audio_data), server_fmt))
+
+    client.add_audio_chunk_listener(on_audio_chunk)
+    client.add_disconnect_listener(lambda: chunk_queue.put_nowait(None))
+
+    try:
+        await client.connect(url)
+        logger.info("Connected to upstream server: %s", url)
+
+        while True:
+            item = await chunk_queue.get()
+            if item is None:
+                logger.warning("Upstream server disconnected")
+                break
+            upstream_ts, pcm_data, server_fmt = item
+
+            # Convert the upstream server timestamp to local/bridge server
+            # time.  compute_play_time returns loop-time minus static_delay.
+            # With static_delay_ms=0 (the default) this is just the local
+            # equivalent of the upstream timestamp -- which is exactly the
+            # bridge server's own clock base (both use loop.time()).
+            bridge_play_us = client.compute_play_time(upstream_ts)
+
+            stream.prepare_audio(pcm_data, server_fmt)
+            await stream.commit_audio(play_start_us=bridge_play_us)
+    finally:
+        stream.stop()
+        await client.disconnect()
 
 
 async def run_server(config: ServeConfig) -> int:
@@ -251,11 +330,19 @@ async def run_server(config: ServeConfig) -> int:
 
             assert active_group is not None
 
-            # Decode and stream audio
+            # Stream audio from source or upstream Sendspin server
             try:
-                audio_source = await decode_audio(config.source, source_format=config.source_format)
                 stream = active_group.start_stream()
-                play_media_task = create_task(_stream_audio(stream, audio_source))
+                if config.sendspin_url:
+                    play_media_task = create_task(
+                        _stream_from_sendspin(stream, config.sendspin_url)
+                    )
+                else:
+                    assert config.source is not None
+                    audio_source = await decode_audio(
+                        config.source, source_format=config.source_format
+                    )
+                    play_media_task = create_task(_stream_audio(stream, audio_source))
                 await play_media_task
                 consecutive_errors = 0
             except asyncio.CancelledError:

--- a/sendspin/settings.py
+++ b/sendspin/settings.py
@@ -223,6 +223,7 @@ class ServeSettings(BaseSettings):
     source: str | None = None
     source_format: str | None = None
     clients: list[str] | None = None
+    sendspin: str | None = None
 
     def update(
         self,
@@ -233,6 +234,7 @@ class ServeSettings(BaseSettings):
         source: str | None = None,
         source_format: str | None = None,
         clients: list[str] | None = None,
+        sendspin: str | None = None,
     ) -> None:
         """Update settings fields. Only changed fields trigger a save."""
         changed = self._update_fields(
@@ -243,6 +245,7 @@ class ServeSettings(BaseSettings):
                 "source": source,
                 "source_format": source_format,
                 "clients": clients,
+                "sendspin": sendspin,
             }
         )
 
@@ -263,6 +266,7 @@ class ServeSettings(BaseSettings):
             self.source = data.get("source")
             self.source_format = data.get("source_format")
             self.clients = data.get("clients")
+            self.sendspin = data.get("sendspin")
             logger.info("Loaded settings from %s", self._settings_file)
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to load settings from %s: %s", self._settings_file, e)


### PR DESCRIPTION
Bridge a Sendspin server to another server, to allow handling more clients.

```
uvx --from git+https://github.com/sendspin/sendspin-cli@serve-sendspin sendspin serve --demo --port 8927
uvx --from git+https://github.com/sendspin/sendspin-cli@serve-sendspin sendspin serve --sendspin ws://localhost:8927/sendspin --port 8928
uvx --from git+https://github.com/sendspin/sendspin-cli@serve-sendspin sendspin serve --sendspin ws://localhost:8927/sendspin --port 8929
```

You can play from all 3 servers at the same time, fully in sync.