### PR TITLE
Implement backpressure and delay in multi-worker mode

### DIFF
--- a/sendspin/serve/coordinator.py
+++ b/sendspin/serve/coordinator.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 # Keep at least 5s of buffer on workers/connected clients
 MAX_BUFFER_AHEAD_US = 5_000_000
 
+# Max queued chunks per worker before the coordinator blocks.
+# Provides backpressure so no worker falls too far behind.
+_WORKER_QUEUE_MAXSIZE = 8
+
+# Extra initial delay (on top of DEFAULT_INITIAL_DELAY_US) to absorb
+# IPC + encoding pipeline latency across multiple workers.
+_MULTI_WORKER_EXTRA_DELAY_US = 250_000  # 250 ms
+
 
 class ServeCoordinator:
     """Orchestrates multi-worker serve mode."""
@@ -117,7 +125,9 @@ class ServeCoordinator:
     def _spawn_workers(self) -> None:
         """Spawn worker subprocesses."""
         for i in range(self.workers):
-            audio_queue: mp.Queue = self._ctx.Queue()  # type: ignore[type-arg]
+            audio_queue: mp.Queue = self._ctx.Queue(  # type: ignore[type-arg]
+                maxsize=_WORKER_QUEUE_MAXSIZE,
+            )
             self._audio_queues.append(audio_queue)
 
             p = self._ctx.Process(
@@ -230,6 +240,19 @@ class ServeCoordinator:
         summary = ", ".join(parts) if parts else "no workers reporting"
         print(f"[stats] {total} clients connected ({summary})")  # noqa: T201
 
+    async def _fan_out_chunk(self, chunk_msg: AudioChunk) -> None:
+        """Put a chunk into all worker queues in parallel, with backpressure.
+
+        Uses run_in_executor so the event loop stays responsive while waiting
+        for bounded queues to accept the item.
+        """
+        loop = asyncio.get_running_loop()
+
+        async def _put(q: mp.Queue) -> None:  # type: ignore[type-arg]
+            await loop.run_in_executor(None, q.put, chunk_msg)
+
+        await asyncio.gather(*[_put(q) for q in self._audio_queues])
+
     async def _stream_audio_loop(self) -> None:
         """Decode audio and fan out PCM chunks to all workers.
 
@@ -237,13 +260,14 @@ class ServeCoordinator:
         """
         consecutive_errors = 0
         last_stats_time = time.monotonic()
+        initial_delay_us = DEFAULT_INITIAL_DELAY_US + _MULTI_WORKER_EXTRA_DELAY_US
 
         while not self._shutdown_requested:
             try:
                 audio_source = await decode_audio(self.source, source_format=self.source_format)
                 fmt = audio_source.format
 
-                play_start_us = int(time.monotonic() * 1_000_000) + DEFAULT_INITIAL_DELAY_US
+                play_start_us = int(time.monotonic() * 1_000_000) + initial_delay_us
 
                 async for pcm_chunk in audio_source.generator:
                     if self._shutdown_requested:
@@ -273,13 +297,12 @@ class ServeCoordinator:
                         channels=fmt.channels,
                         play_start_us=play_start_us,
                     )
-                    for queue in self._audio_queues:
-                        queue.put(chunk_msg)
+                    await self._fan_out_chunk(chunk_msg)
 
                     play_start_us += chunk_duration_us
 
                     now_us = int(time.monotonic() * 1_000_000)
-                    ahead_us = play_start_us - DEFAULT_INITIAL_DELAY_US - now_us
+                    ahead_us = play_start_us - initial_delay_us - now_us
                     if ahead_us > MAX_BUFFER_AHEAD_US:
                         await asyncio.sleep((ahead_us - MAX_BUFFER_AHEAD_US) / 1_000_000)
 

--- a/sendspin/serve/server.py
+++ b/sendspin/serve/server.py
@@ -1,5 +1,7 @@
 """Custom SendspinServer with embedded web player."""
 
+from __future__ import annotations
+
 from importlib.resources import files
 from multiprocessing.sharedctypes import Synchronized
 from pathlib import Path

--- a/tests/serve/test_coordinator.py
+++ b/tests/serve/test_coordinator.py
@@ -7,8 +7,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sendspin.serve.coordinator import ServeCoordinator
-from sendspin.serve.ipc import WorkerClientCount, WorkerError, WorkerListening
+from sendspin.serve.coordinator import (
+    ServeCoordinator,
+    _MULTI_WORKER_EXTRA_DELAY_US,
+    _WORKER_QUEUE_MAXSIZE,
+)
+from sendspin.serve.ipc import AudioChunk, WorkerClientCount, WorkerError, WorkerListening
 
 
 @pytest.fixture
@@ -87,6 +91,40 @@ def test_check_worker_health_ignores_startup_failed_workers(coordinator: ServeCo
     coordinator._check_worker_health()
 
     assert coordinator._shutdown_requested is False
+
+
+def test_worker_queue_maxsize_is_bounded() -> None:
+    """Worker queues should be created with a bounded maxsize for backpressure."""
+    assert _WORKER_QUEUE_MAXSIZE > 0
+
+
+def test_multi_worker_extra_delay_is_positive() -> None:
+    """Multi-worker mode should add extra initial delay for IPC latency."""
+    assert _MULTI_WORKER_EXTRA_DELAY_US > 0
+
+
+@pytest.mark.asyncio
+async def test_fan_out_chunk_sends_to_all_workers(coordinator: ServeCoordinator) -> None:
+    """_fan_out_chunk should put the chunk into every worker queue."""
+    # Manually create bounded queues (simulating _spawn_workers)
+    import multiprocessing as mp
+
+    ctx = mp.get_context("spawn")
+    coordinator._audio_queues = [ctx.Queue(maxsize=_WORKER_QUEUE_MAXSIZE) for _ in range(2)]
+
+    chunk = AudioChunk(
+        pcm_bytes=b"\x00" * 100,
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        play_start_us=1_000_000,
+    )
+    await coordinator._fan_out_chunk(chunk)
+
+    for q in coordinator._audio_queues:
+        msg = q.get(timeout=1)
+        assert isinstance(msg, AudioChunk)
+        assert msg.pcm_bytes == chunk.pcm_bytes
 
 
 def test_check_worker_health_shuts_down_on_unexpected_worker_crash(


### PR DESCRIPTION
## Summary
- **Bounded queues with backpressure**: Worker queues are now bounded to 8 chunks. When full, the coordinator blocks until the worker catches up, preventing unbounded memory growth if a worker falls behind.
- **Non-blocking fan-out via `_fan_out_chunk`**: Replaced synchronous `queue.put()` loop with `run_in_executor` + `asyncio.gather` to put to all workers in parallel, keeping the event loop responsive.
- **Extra initial delay (+250ms)**: Adds headroom for IPC latency across process boundaries so playback timestamps stay synchronized.

## Test plan
- [x] Added tests for `_WORKER_QUEUE_MAXSIZE` and `_MULTI_WORKER_EXTRA_DELAY_US` constants
- [x] Added test verifying `_fan_out_chunk` delivers to all worker queues
- [ ] Manual test with multiple workers to verify backpressure doesn't cause audio stuttering