### PR TITLE
Upgrade sendspin-js SDK from v2.0.5 to v3.0.0

### DIFF
--- a/sendspin/serve/web/app.js
+++ b/sendspin/serve/web/app.js
@@ -644,7 +644,7 @@ elements.listenToggleBtn.addEventListener("click", async () => {
 });
 
 const sdkImport = import(
-  "https://unpkg.com/@sendspin/sendspin-js@2.0.5/dist/index.js?module",
+  "https://unpkg.com/@sendspin/sendspin-js@3.0.0/dist/index.js?module",
 );
 
 // QR Code generation (using qrcode-generator loaded via script tag)


### PR DESCRIPTION
## Summary
Updates the sendspin-js SDK dependency to the latest major version (v3.0.0) in the web application.

## Key Changes
- Updated SDK import URL from `@sendspin/sendspin-js@2.0.5` to `@sendspin/sendspin-js@3.0.0`

## Implementation Details
The SDK is dynamically imported via unpkg CDN in the web app initialization. This upgrade to v3.0.0 brings the application to the latest major version of the sendspin-js library, which may include breaking changes, new features, or improvements. Users should verify that the application functionality remains intact with the new SDK version.

https://claude.ai/code/session_01AxTjrk8DnF21ZiEsX2VKA5