### PR TITLE
fix: detect TAS58xx 'volume volume-joined' capability for ALSA volume control

### DIFF
--- a/sendspin/alsa_volume.py
+++ b/sendspin/alsa_volume.py
@@ -29,7 +29,7 @@ _POLL_INTERVAL_S = 1.0
 
 # Well-known ALSA mixer element names, in priority order.
 # When multiple elements have playback volume, prefer these over others.
-# - Digital: HiFiBerry DAC+/DAC2/Amp2, most I2S DAC HATs (PCM5122)
+# - Digital: HiFiBerry DAC+/DAC2/Amp2, most I2S DAC HATs (PCM5122), TAS58xx amplifiers (Louder Raspberry)
 # - Master: HiFiBerry Amp+, generic ALSA cards, many USB interfaces
 # - PCM: bcm2835 headphones, some USB DACs
 _PREFERRED_ELEMENTS: tuple[str, ...] = ("Digital", "Master", "PCM")
@@ -48,7 +48,12 @@ def parse_alsa_card(device_name: str) -> int | None:
 
 
 async def _has_playback_volume(card: int, element: str) -> bool:
-    """Check if an ALSA mixer element has playback volume capability."""
+    """Check if an ALSA mixer element has playback volume capability.
+
+    Accepts both ``pvolume`` (standard playback volume, e.g. HiFiBerry DAC+,
+    USB interfaces) and ``volume volume-joined`` (used by TAS58xx-based
+    amplifier HATs such as the Sonocotta Louder Raspberry).
+    """
     try:
         proc = await asyncio.create_subprocess_exec(
             "amixer",
@@ -65,14 +70,18 @@ async def _has_playback_volume(card: int, element: str) -> bool:
         return False
     if proc.returncode != 0:
         return False
-    return "pvolume" in stdout.decode()
+    decoded = stdout.decode()
+    # TAS58xx amplifiers (e.g. Sonocotta Louder Raspberry) report
+    # 'volume volume-joined' instead of the standard 'pvolume'.
+    return "pvolume" in decoded or "volume volume-joined" in decoded
 
 
 async def find_mixer_element(card: int) -> str | None:
     """Discover the playback volume mixer element on an ALSA card.
 
     Runs ``amixer -c <card> scontrols``, then checks each element for
-    playback volume (``pvolume``) capability.  Prefers well-known element
+    playback volume capability (``pvolume`` or ``volume volume-joined``).
+    Prefers well-known element
     names (Digital, Master, PCM) when multiple elements have playback
     volume.  Returns the best match, or None if no element has playback
     volume control.
@@ -123,7 +132,7 @@ async def find_mixer_element(card: int) -> str | None:
             logger.debug("ALSA card %d: selected preferred mixer element %r", card, preferred)
             return preferred
 
-    # Fallback: first element with pvolume (e.g. USB DACs with non-standard names).
+    # Fallback: first element with playback volume (e.g. USB DACs with non-standard names).
     selected = pvolume_elements[0]
     logger.debug("ALSA card %d: selected mixer element %r", card, selected)
     return selected

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -481,3 +481,106 @@ def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
         assert muted is False
 
     asyncio.run(exercise())
+
+
+# -- Simulated Sonocotta Louder Raspberry HAT scenario -----------------------
+# Reproduces the exact setup from a Raspberry Pi with a Sonocotta Louder
+# Raspberry HAT (TI TAS5825M amplifier chip) on card 2.  The TAS58xx driver
+# reports "volume volume-joined" capability for the Digital control instead
+# of the standard "pvolume", which previously caused find_mixer_element to
+# return None and left the daemon with no working volume control.
+
+
+# Real amixer output from a Sonocotta Louder Raspberry HAT (TAS5825M chip)
+_TAS58XX_SCONTROLS = (
+    "Simple mixer control 'Analog Gain',0
+"
+    "Simple mixer control 'Channel Left Gain',0
+"
+    "Simple mixer control 'Channel Right Gain',0
+"
+    "Simple mixer control 'Digital',0
+"
+)
+
+_TAS58XX_SGET_DIGITAL = (
+    "Simple mixer control 'Digital',0
+"
+    "  Capabilities: volume volume-joined
+"
+    "  Playback channels: Mono
+"
+    "  Capture channels: Mono
+"
+    "  Limits: 0 - 127
+"
+    "  Mono: 73 [57%]
+"
+)
+
+_TAS58XX_SGET_NO_VOLUME = (
+    "Simple mixer control 'Analog Gain',0
+"
+    "  Capabilities: volume volume-joined
+"
+    "  Playback channels: Mono
+"
+    "  Limits: 0 - 31
+"
+    "  Mono: 31 [100%]
+"
+)
+
+# The exact PortAudio device name for this HAT
+_TAS58XX_DEVICE_NAME = (
+    "Louder-Raspberry: bcm2835-i2s-tas58xx-amplifier tas58xx-amplifier-0 (hw:2,0)"
+)
+
+
+def test_find_mixer_element_tas58xx(monkeypatch) -> None:
+    """TAS58xx amplifiers report 'volume volume-joined', not 'pvolume'."""
+
+    async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
+        if "scontrols" in argv:
+            return _FakeProcess(stdout=_TAS58XX_SCONTROLS.encode())
+        if "Digital" in argv:
+            return _FakeProcess(stdout=_TAS58XX_SGET_DIGITAL.encode())
+        return _FakeProcess(stdout=_TAS58XX_SGET_NO_VOLUME.encode())
+
+    async def exercise() -> str | None:
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        return await find_mixer_element(2)
+
+    assert asyncio.run(exercise()) == "Digital"
+
+
+def test_louder_raspberry_discovery(monkeypatch) -> None:
+    """Full discovery flow for a Sonocotta Louder Raspberry HAT on card 2."""
+
+    async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
+        if "scontrols" in argv:
+            return _FakeProcess(stdout=_TAS58XX_SCONTROLS.encode())
+        if "Digital" in argv:
+            return _FakeProcess(stdout=_TAS58XX_SGET_DIGITAL.encode())
+        return _FakeProcess(stdout=_TAS58XX_SGET_NO_VOLUME.encode())
+
+    async def exercise() -> tuple[int, str] | None:
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        device = SimpleNamespace(name=_TAS58XX_DEVICE_NAME, is_default=False)
+        return await async_check_alsa_available(device)
+
+    result = asyncio.run(exercise())
+    assert result == (2, "Digital")
+
+
+def test_louder_raspberry_get_volume(monkeypatch) -> None:
+    """get_state reads back the correct volume from a TAS58xx Digital control."""
+
+    async def exercise() -> tuple[int, bool]:
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(_TAS58XX_SGET_DIGITAL))
+        ctrl = AlsaVolumeController(card=2, element="Digital")
+        return await ctrl.get_state()
+
+    volume, muted = asyncio.run(exercise())
+    assert volume == 57
+    assert muted is False


### PR DESCRIPTION
## Problem

The `_has_playback_volume()` helper only accepted mixer elements reporting `pvolume` capability. TAS58xx-based amplifier HATs — including the **Sonocotta Louder Raspberry** (TI TAS5825M) — report `volume volume-joined` instead:

```
Simple mixer control 'Digital',0
  Capabilities: volume volume-joined
  Playback channels: Mono
  Limits: 0 - 127
  Mono: 73 [57%]
```

This caused `find_mixer_element()` to return `None` for the card, which silently fell through to the PulseAudio backend (also unavailable on bare ALSA systems), leaving the daemon with no working volume control despite `"audio_device": "Louder-Raspberry"` being correctly configured.

## Fix

Also accept `volume volume-joined` as a valid playback volume capability in `_has_playback_volume()`:

```python
decoded = stdout.decode()
return "pvolume" in decoded or "volume volume-joined" in decoded
```

## Tests

Added three tests under a new *Sonocotta Louder Raspberry HAT scenario* section in `tests/test_alsa_volume.py`, using real `amixer` output captured from the device:

- `test_find_mixer_element_tas58xx` — `Digital` is found on a TAS58xx card
- `test_louder_raspberry_discovery` — full `async_check_alsa_available` flow returns `(2, "Digital")`
- `test_louder_raspberry_get_volume` — `get_state` parses the mono volume line correctly

## Hardware

Raspberry Pi 5, Sonocotta Louder Raspberry HAT (TI TAS5825M), ALSA card `Louder-Raspberry` (card 2), control `Digital`, range 0–127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)