### PR TITLE
Fix ALSA device matching for hw:CARD=...,DEV=... format

### DIFF
--- a/sendspin/audio_devices.py
+++ b/sendspin/audio_devices.py
@@ -321,6 +321,12 @@ def _try_alsa_device(name: str) -> AudioDevice | None:
         sounddevice.check_output_settings(device=name)
     except sounddevice.PortAudioError:
         return None
+    except ValueError:
+        # PortAudio doesn't recognize this device name (e.g. hw:CARD=...,DEV=...).
+        # Validate it exists in ALSA before accepting it with safe defaults.
+        alsa_names = {dev_name for dev_name, _ in list_alsa_devices()}
+        if name not in alsa_names:
+            return None
 
     # Try to query device info from PortAudio
     try:

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -1,0 +1,110 @@
+"""Tests for ALSA device resolution in audio_devices.py."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import sounddevice
+
+import sendspin.audio_devices as _mod
+from sendspin.audio_devices import _try_alsa_device
+
+
+def test_try_alsa_device_returns_device_when_portaudio_accepts():
+    """Device recognized by PortAudio is returned with queried info."""
+    info = {
+        "name": "jsm_speaker_left",
+        "max_output_channels": 128,
+        "default_samplerate": 48000.0,
+    }
+    with (
+        patch.object(sounddevice, "check_output_settings"),
+        patch.object(sounddevice, "query_devices", return_value=info),
+    ):
+        result = _try_alsa_device("jsm_speaker_left")
+
+    assert result is not None
+    assert result.alsa_device_name == "jsm_speaker_left"
+    assert result.output_channels == 128
+    assert result.sample_rate == 48000.0
+
+
+def test_try_alsa_device_returns_none_on_portaudio_error():
+    """PortAudioError from check_output_settings means device can't be opened."""
+    with patch.object(
+        sounddevice,
+        "check_output_settings",
+        side_effect=sounddevice.PortAudioError("err", -1, ""),
+    ):
+        assert _try_alsa_device("nonexistent") is None
+
+
+def test_try_alsa_device_accepts_hw_card_format_known_to_alsa():
+    """hw:CARD=...,DEV=... that PortAudio doesn't know but ALSA lists should work."""
+    alsa_list = [
+        (
+            "hw:CARD=sndrpihifiberry,DEV=0",
+            "snd_rpi_hifiberry_dacplus, HiFiBerry DAC+ HiFi",
+        ),
+    ]
+    with (
+        patch.object(
+            sounddevice,
+            "check_output_settings",
+            side_effect=ValueError("not found"),
+        ),
+        patch.object(_mod, "list_alsa_devices", return_value=alsa_list),
+    ):
+        result = _try_alsa_device("hw:CARD=sndrpihifiberry,DEV=0")
+
+    assert result is not None
+    assert result.alsa_device_name == "hw:CARD=sndrpihifiberry,DEV=0"
+    assert result.output_channels == 2
+    assert result.sample_rate == 48000.0
+
+
+def test_try_alsa_device_returns_none_for_unknown_hw_card():
+    """hw:CARD=...,DEV=... not in ALSA list should return None."""
+    with (
+        patch.object(
+            sounddevice,
+            "check_output_settings",
+            side_effect=ValueError("not found"),
+        ),
+        patch.object(_mod, "list_alsa_devices", return_value=[]),
+    ):
+        assert _try_alsa_device("hw:CARD=nonexistent,DEV=0") is None
+
+
+def test_try_alsa_device_uses_safe_defaults_when_query_fails():
+    """PortAudio accepts the device but can't query info → safe defaults."""
+    with (
+        patch.object(sounddevice, "check_output_settings"),
+        patch.object(
+            sounddevice,
+            "query_devices",
+            side_effect=sounddevice.PortAudioError("err", -1, ""),
+        ),
+    ):
+        result = _try_alsa_device("jsm_speaker_left")
+
+    assert result is not None
+    assert result.output_channels == 2
+    assert result.sample_rate == 48000.0
+
+
+def test_try_alsa_device_accepts_alsa_only_device():
+    """ALSA-only device (e.g. bluealsa) not known to PortAudio should work."""
+    alsa_list = [("bluealsa", "Bluetooth Audio")]
+    with (
+        patch.object(
+            sounddevice,
+            "check_output_settings",
+            side_effect=ValueError("not found"),
+        ),
+        patch.object(_mod, "list_alsa_devices", return_value=alsa_list),
+    ):
+        result = _try_alsa_device("bluealsa")
+
+    assert result is not None
+    assert result.alsa_device_name == "bluealsa"

--- a/tests/test_audio_devices.py
+++ b/tests/test_audio_devices.py
@@ -53,6 +53,11 @@ def test_try_alsa_device_accepts_hw_card_format_known_to_alsa():
             "check_output_settings",
             side_effect=ValueError("not found"),
         ),
+        patch.object(
+            sounddevice,
+            "query_devices",
+            side_effect=ValueError("not found"),
+        ),
         patch.object(_mod, "list_alsa_devices", return_value=alsa_list),
     ):
         result = _try_alsa_device("hw:CARD=sndrpihifiberry,DEV=0")
@@ -100,6 +105,11 @@ def test_try_alsa_device_accepts_alsa_only_device():
         patch.object(
             sounddevice,
             "check_output_settings",
+            side_effect=ValueError("not found"),
+        ),
+        patch.object(
+            sounddevice,
+            "query_devices",
             side_effect=ValueError("not found"),
         ),
         patch.object(_mod, "list_alsa_devices", return_value=alsa_list),


### PR DESCRIPTION
## Summary
- Catch `ValueError` (in addition to `PortAudioError`) from `sounddevice.check_output_settings` — PortAudio raises `ValueError` for `hw:CARD=...,DEV=...` names it doesn't recognize
- Validate the device exists in the ALSA device list before accepting it with safe defaults
- Add focused tests for `_try_alsa_device`

Simpler alternative to #218 — 6 lines changed in production code vs ~80.

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)