### PR TITLE
Support TAS58xx 'volume' capability for ALSA volume control

### DIFF
--- a/sendspin/alsa_volume.py
+++ b/sendspin/alsa_volume.py
@@ -109,15 +109,15 @@ async def find_mixer_element(card: int) -> str | None:
         return None
 
     seen: set[str] = set()
-    pvolume_elements: list[str] = []
+    volume_elements: list[str] = []
     for element in available:
         if element in seen:
             continue
         seen.add(element)
         if await _has_playback_volume(card, element):
-            pvolume_elements.append(element)
+            volume_elements.append(element)
 
-    if not pvolume_elements:
+    if not volume_elements:
         logger.debug(
             "ALSA card %d: no playback volume element among %s",
             card,
@@ -127,12 +127,12 @@ async def find_mixer_element(card: int) -> str | None:
 
     # Prefer well-known element names used by common DAC HATs.
     for preferred in _PREFERRED_ELEMENTS:
-        if preferred in pvolume_elements:
+        if preferred in volume_elements:
             logger.debug("ALSA card %d: selected preferred mixer element %r", card, preferred)
             return preferred
 
     # Fallback: first element with playback volume (e.g. USB DACs with non-standard names).
-    selected = pvolume_elements[0]
+    selected = volume_elements[0]
     logger.debug("ALSA card %d: selected mixer element %r", card, selected)
     return selected
 

--- a/sendspin/alsa_volume.py
+++ b/sendspin/alsa_volume.py
@@ -29,7 +29,7 @@ _POLL_INTERVAL_S = 1.0
 
 # Well-known ALSA mixer element names, in priority order.
 # When multiple elements have playback volume, prefer these over others.
-# - Digital: HiFiBerry DAC+/DAC2/Amp2, most I2S DAC HATs (PCM5122)
+# - Digital: HiFiBerry DAC+/DAC2/Amp2, most I2S DAC HATs (PCM5122), TAS58xx amplifiers (Louder Raspberry)
 # - Master: HiFiBerry Amp+, generic ALSA cards, many USB interfaces
 # - PCM: bcm2835 headphones, some USB DACs
 _PREFERRED_ELEMENTS: tuple[str, ...] = ("Digital", "Master", "PCM")
@@ -48,7 +48,13 @@ def parse_alsa_card(device_name: str) -> int | None:
 
 
 async def _has_playback_volume(card: int, element: str) -> bool:
-    """Check if an ALSA mixer element has playback volume capability."""
+    """Check if an ALSA mixer element has playback volume capability.
+
+    Accepts both ``pvolume`` (standard playback volume, e.g. HiFiBerry DAC+,
+    USB interfaces) and ``volume`` (used by TAS58xx-based amplifier HATs such
+    as the Sonocotta Louder Raspberry — reported as ``volume`` in stereo mode
+    or ``volume volume-joined`` in mono mode).
+    """
     try:
         proc = await asyncio.create_subprocess_exec(
             "amixer",
@@ -65,14 +71,16 @@ async def _has_playback_volume(card: int, element: str) -> bool:
         return False
     if proc.returncode != 0:
         return False
-    return "pvolume" in stdout.decode()
+    caps = set(stdout.decode().split())
+    return "pvolume" in caps or "volume" in caps
 
 
 async def find_mixer_element(card: int) -> str | None:
     """Discover the playback volume mixer element on an ALSA card.
 
     Runs ``amixer -c <card> scontrols``, then checks each element for
-    playback volume (``pvolume``) capability.  Prefers well-known element
+    playback volume capability (``pvolume`` or ``volume``).
+    Prefers well-known element
     names (Digital, Master, PCM) when multiple elements have playback
     volume.  Returns the best match, or None if no element has playback
     volume control.
@@ -123,7 +131,7 @@ async def find_mixer_element(card: int) -> str | None:
             logger.debug("ALSA card %d: selected preferred mixer element %r", card, preferred)
             return preferred
 
-    # Fallback: first element with pvolume (e.g. USB DACs with non-standard names).
+    # Fallback: first element with playback volume (e.g. USB DACs with non-standard names).
     selected = pvolume_elements[0]
     logger.debug("ALSA card %d: selected mixer element %r", card, selected)
     return selected

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -5,6 +5,8 @@ from collections.abc import Awaitable, Callable
 from typing import NoReturn
 from types import SimpleNamespace
 
+import pytest
+
 import sendspin.alsa_volume as _alsa_mod
 from sendspin.alsa_volume import (
     AlsaVolumeController,
@@ -487,8 +489,6 @@ def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
 # The TAS58xx driver reports "volume" (or "volume volume-joined") instead of
 # the standard "pvolume" capability.
 
-import pytest
-
 _TAS58XX_SCONTROLS = (
     "Simple mixer control 'Analog Gain',0\n"
     "Simple mixer control 'Digital',0\n"
@@ -526,15 +526,15 @@ def _tas58xx_exec(digital_output: str) -> _AmixerExecFactory:
 
 
 @pytest.mark.parametrize(
-    ("digital_output", "desc"),
+    "digital_output",
     [
-        (_TAS58XX_SGET_DIGITAL_MONO, "mono (volume volume-joined)"),
-        (_TAS58XX_SGET_DIGITAL_STEREO, "stereo (volume)"),
+        _TAS58XX_SGET_DIGITAL_MONO,
+        _TAS58XX_SGET_DIGITAL_STEREO,
     ],
     ids=["mono", "stereo"],
 )
-def test_find_mixer_element_tas58xx(monkeypatch, digital_output: str, desc: str) -> None:
-    """TAS58xx 'volume' capability is detected — {desc}."""
+def test_find_mixer_element_tas58xx(monkeypatch, digital_output: str) -> None:
+    """TAS58xx 'volume' capability is detected."""
 
     async def exercise() -> str | None:
         monkeypatch.setattr(asyncio, "create_subprocess_exec", _tas58xx_exec(digital_output))

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -481,3 +481,91 @@ def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
         assert muted is False
 
     asyncio.run(exercise())
+
+
+# -- TAS58xx / Sonocotta Louder Raspberry HAT --------------------------------
+# The TAS58xx driver reports "volume" (or "volume volume-joined") instead of
+# the standard "pvolume" capability.
+
+import pytest
+
+_TAS58XX_SCONTROLS = (
+    "Simple mixer control 'Analog Gain',0\n"
+    "Simple mixer control 'Digital',0\n"
+)
+
+_TAS58XX_SGET_DIGITAL_MONO = (
+    "Simple mixer control 'Digital',0\n"
+    "  Capabilities: volume volume-joined\n"
+    "  Playback channels: Mono\n"
+    "  Limits: 0 - 127\n"
+    "  Mono: 73 [57%]\n"
+)
+
+_TAS58XX_SGET_DIGITAL_STEREO = (
+    "Simple mixer control 'Digital',0\n"
+    "  Capabilities: volume\n"
+    "  Playback channels: Front Left - Front Right\n"
+    "  Limits: 0 - 127\n"
+    "  Front Left: 73 [57%]\n"
+    "  Front Right: 73 [57%]\n"
+)
+
+
+def _tas58xx_exec(digital_output: str) -> _AmixerExecFactory:
+    """Build a fake amixer exec for TAS58xx scenarios."""
+
+    async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
+        if "scontrols" in argv:
+            return _FakeProcess(stdout=_TAS58XX_SCONTROLS.encode())
+        if "Digital" in argv:
+            return _FakeProcess(stdout=digital_output.encode())
+        return _FakeProcess(stdout=b"")
+
+    return fake_exec
+
+
+@pytest.mark.parametrize(
+    ("digital_output", "desc"),
+    [
+        (_TAS58XX_SGET_DIGITAL_MONO, "mono (volume volume-joined)"),
+        (_TAS58XX_SGET_DIGITAL_STEREO, "stereo (volume)"),
+    ],
+    ids=["mono", "stereo"],
+)
+def test_find_mixer_element_tas58xx(monkeypatch, digital_output: str, desc: str) -> None:
+    """TAS58xx 'volume' capability is detected — {desc}."""
+
+    async def exercise() -> str | None:
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _tas58xx_exec(digital_output))
+        return await find_mixer_element(2)
+
+    assert asyncio.run(exercise()) == "Digital"
+
+
+def test_louder_raspberry_discovery(monkeypatch) -> None:
+    """Full discovery flow for a Sonocotta Louder Raspberry HAT on card 2."""
+
+    async def exercise() -> tuple[int, str] | None:
+        monkeypatch.setattr(_alsa_mod, "AVAILABLE", True)
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _tas58xx_exec(_TAS58XX_SGET_DIGITAL_MONO))
+        device = SimpleNamespace(
+            name="Louder-Raspberry: bcm2835-i2s-tas58xx-amplifier tas58xx-amplifier-0 (hw:2,0)",
+            is_default=False,
+        )
+        return await async_check_alsa_available(device)
+
+    assert asyncio.run(exercise()) == (2, "Digital")
+
+
+def test_louder_raspberry_get_volume(monkeypatch) -> None:
+    """get_state reads back the correct volume from a TAS58xx Digital control."""
+
+    async def exercise() -> tuple[int, bool]:
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(_TAS58XX_SGET_DIGITAL_MONO))
+        ctrl = AlsaVolumeController(card=2, element="Digital")
+        return await ctrl.get_state()
+
+    volume, muted = asyncio.run(exercise())
+    assert volume == 57
+    assert muted is False

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -489,7 +489,7 @@ def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
 # The TAS58xx driver reports "volume" (or "volume volume-joined") instead of
 # the standard "pvolume" capability.
 
-_TAS58XX_SCONTROLS = "Simple mixer control 'Analog Gain',0\n" "Simple mixer control 'Digital',0\n"
+_TAS58XX_SCONTROLS = "Simple mixer control 'Analog Gain',0\nSimple mixer control 'Digital',0\n"
 
 _TAS58XX_SGET_DIGITAL_MONO = (
     "Simple mixer control 'Digital',0\n"

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -489,10 +489,7 @@ def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
 # The TAS58xx driver reports "volume" (or "volume volume-joined") instead of
 # the standard "pvolume" capability.
 
-_TAS58XX_SCONTROLS = (
-    "Simple mixer control 'Analog Gain',0\n"
-    "Simple mixer control 'Digital',0\n"
-)
+_TAS58XX_SCONTROLS = "Simple mixer control 'Analog Gain',0\n" "Simple mixer control 'Digital',0\n"
 
 _TAS58XX_SGET_DIGITAL_MONO = (
     "Simple mixer control 'Digital',0\n"
@@ -548,7 +545,9 @@ def test_louder_raspberry_discovery(monkeypatch) -> None:
 
     async def exercise() -> tuple[int, str] | None:
         monkeypatch.setattr(_alsa_mod, "AVAILABLE", True)
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _tas58xx_exec(_TAS58XX_SGET_DIGITAL_MONO))
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", _tas58xx_exec(_TAS58XX_SGET_DIGITAL_MONO)
+        )
         device = SimpleNamespace(
             name="Louder-Raspberry: bcm2835-i2s-tas58xx-amplifier tas58xx-amplifier-0 (hw:2,0)",
             is_default=False,
@@ -562,7 +561,9 @@ def test_louder_raspberry_get_volume(monkeypatch) -> None:
     """get_state reads back the correct volume from a TAS58xx Digital control."""
 
     async def exercise() -> tuple[int, bool]:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(_TAS58XX_SGET_DIGITAL_MONO))
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", _amixer_exec(_TAS58XX_SGET_DIGITAL_MONO)
+        )
         ctrl = AlsaVolumeController(card=2, element="Digital")
         return await ctrl.get_state()
 


### PR DESCRIPTION
## Summary
- Detect `volume` (not just `pvolume`) in ALSA mixer capabilities, fixing hardware volume control for TAS58xx-based DAC HATs like the Sonocotta Louder Raspberry
- Add parametrized tests covering mono (`volume volume-joined`) and stereo (`volume`) modes, plus discovery and get_volume flows
- Fix test portability by monkeypatching `AVAILABLE` so discovery tests pass on non-Linux CI

Based on the work in #214 by @chaudis, with simplified tests.

Closes #214

## Test plan
- [x] `test_find_mixer_element_tas58xx[mono]` — detects `volume volume-joined`
- [x] `test_find_mixer_element_tas58xx[stereo]` — detects `volume`
- [x] `test_louder_raspberry_discovery` — full device→card→element flow
- [x] `test_louder_raspberry_get_volume` — reads back correct volume percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)