### PR TITLE
Convert ALSA volume tests to native async def

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
   "pre-commit==4.4.0",
   "pre-commit-hooks==6.0.0",
   "pytest>=8.4.2",
+  "pytest-asyncio>=1.0.0",
   "ruff==0.14.5",
 ]
 
@@ -146,6 +147,9 @@ ignore = [
 "setup.py" = ["T201"]
 
 select = ["ALL"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -63,7 +63,7 @@ def test_parse_card_returns_none_for_virtual_device() -> None:
 # -- find_mixer_element -------------------------------------------------------
 
 
-def test_find_mixer_element_digital(monkeypatch) -> None:
+async def test_find_mixer_element_digital(monkeypatch) -> None:
     """HiFiBerry DAC+ exposes 'Digital' as the volume control."""
     scontrols = (
         "Simple mixer control 'Analogue',0\n"
@@ -79,20 +79,15 @@ def test_find_mixer_element_digital(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=scontrols.encode())
-        # On real HiFiBerry DAC+ (PCM5122), both Analogue and Digital
-        # have pvolume. The preference logic should pick Digital.
         if "Analogue" in argv or "Digital" in argv:
             return _FakeProcess(stdout=sget_with_pvolume.encode())
         return _FakeProcess(stdout=sget_without_pvolume.encode())
 
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        return await find_mixer_element(1)
-
-    assert asyncio.run(exercise()) == "Digital"
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await find_mixer_element(1) == "Digital"
 
 
-def test_find_mixer_element_prefers_digital_over_analogue(monkeypatch) -> None:
+async def test_find_mixer_element_prefers_digital_over_analogue(monkeypatch) -> None:
     """When both Analogue and Digital have pvolume, Digital is preferred."""
     scontrols = "Simple mixer control 'Analogue',0\nSimple mixer control 'Digital',0\n"
     sget_with_pvolume = "  Capabilities: pvolume pswitch\n"
@@ -102,14 +97,11 @@ def test_find_mixer_element_prefers_digital_over_analogue(monkeypatch) -> None:
             return _FakeProcess(stdout=scontrols.encode())
         return _FakeProcess(stdout=sget_with_pvolume.encode())
 
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        return await find_mixer_element(1)
-
-    assert asyncio.run(exercise()) == "Digital"
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await find_mixer_element(1) == "Digital"
 
 
-def test_find_mixer_element_master(monkeypatch) -> None:
+async def test_find_mixer_element_master(monkeypatch) -> None:
     """HiFiBerry Amp+ uses 'Master' for volume."""
     scontrols = "Simple mixer control 'Channels',0\nSimple mixer control 'Master',0\n"
     sget_pvolume = "  Capabilities: pvolume pswitch\n"
@@ -122,47 +114,33 @@ def test_find_mixer_element_master(monkeypatch) -> None:
             return _FakeProcess(stdout=sget_pvolume.encode())
         return _FakeProcess(stdout=sget_no_pvolume.encode())
 
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        return await find_mixer_element(1)
-
-    assert asyncio.run(exercise()) == "Master"
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await find_mixer_element(1) == "Master"
 
 
-def test_find_mixer_element_none_when_no_controls(monkeypatch) -> None:
+async def test_find_mixer_element_none_when_no_controls(monkeypatch) -> None:
     """PCM5102A boards have no mixer controls."""
-
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(""))
-        return await find_mixer_element(1)
-
-    assert asyncio.run(exercise()) is None
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(""))
+    assert await find_mixer_element(1) is None
 
 
-def test_find_mixer_element_none_on_amixer_failure(monkeypatch) -> None:
+async def test_find_mixer_element_none_on_amixer_failure(monkeypatch) -> None:
     """Gracefully handle amixer failure (e.g., card not found)."""
-
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec("", returncode=1))
-        return await find_mixer_element(99)
-
-    assert asyncio.run(exercise()) is None
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec("", returncode=1))
+    assert await find_mixer_element(99) is None
 
 
-def test_find_mixer_element_none_when_amixer_not_found(monkeypatch) -> None:
+async def test_find_mixer_element_none_when_amixer_not_found(monkeypatch) -> None:
     """Gracefully handle amixer not being installed."""
 
     async def not_found(*args: object, **kwargs: object) -> NoReturn:
         raise FileNotFoundError("amixer")
 
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", not_found)
-        return await find_mixer_element(1)
-
-    assert asyncio.run(exercise()) is None
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", not_found)
+    assert await find_mixer_element(1) is None
 
 
-def test_find_mixer_element_capability_scan_fallback(monkeypatch) -> None:
+async def test_find_mixer_element_capability_scan_fallback(monkeypatch) -> None:
     """Falls back to capability scan for USB devices with non-standard names."""
     scontrols_output = (
         "Simple mixer control 'Mic',0\n"
@@ -180,19 +158,15 @@ def test_find_mixer_element_capability_scan_fallback(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=scontrols_output.encode())
-        # sget calls: return capabilities based on element name
         if "Mic" in argv:
             return _FakeProcess(stdout=sget_mic.encode())
         return _FakeProcess(stdout=sget_output.encode())
 
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        return await find_mixer_element(3)
-
-    assert asyncio.run(exercise()) == "UMC202HD 192k Output"
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await find_mixer_element(3) == "UMC202HD 192k Output"
 
 
-def test_find_mixer_element_capability_scan_skips_capture_only(monkeypatch) -> None:
+async def test_find_mixer_element_capability_scan_skips_capture_only(monkeypatch) -> None:
     """Capability scan skips elements that only have capture volume."""
     scontrols_output = "Simple mixer control 'Mic',0\n"
     sget_mic = "Simple mixer control 'Mic',0\n  Capabilities: cvolume cswitch\n"
@@ -202,17 +176,14 @@ def test_find_mixer_element_capability_scan_skips_capture_only(monkeypatch) -> N
             return _FakeProcess(stdout=scontrols_output.encode())
         return _FakeProcess(stdout=sget_mic.encode())
 
-    async def exercise() -> str | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        return await find_mixer_element(3)
-
-    assert asyncio.run(exercise()) is None
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await find_mixer_element(3) is None
 
 
 # -- AlsaVolumeController.set_state ------------------------------------------
 
 
-def test_set_state_calls_amixer_sset(monkeypatch) -> None:
+async def test_set_state_calls_amixer_sset(monkeypatch) -> None:
     """set_state runs amixer sset with percentage and mute/unmute."""
     calls: list[tuple[str, ...]] = []
 
@@ -220,16 +191,13 @@ def test_set_state_calls_amixer_sset(monkeypatch) -> None:
         calls.append(argv)
         return _FakeProcess()
 
-    async def exercise() -> None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        ctrl = AlsaVolumeController(card=1, element="Digital")
-        await ctrl.set_state(75, muted=False)
-
-    asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    ctrl = AlsaVolumeController(card=1, element="Digital")
+    await ctrl.set_state(75, muted=False)
     assert calls == [("amixer", "-M", "-c", "1", "sset", "Digital", "playback", "75%", "unmute")]
 
 
-def test_set_state_muted(monkeypatch) -> None:
+async def test_set_state_muted(monkeypatch) -> None:
     """When muted, amixer is called with 'mute'."""
     calls: list[tuple[str, ...]] = []
 
@@ -237,19 +205,16 @@ def test_set_state_muted(monkeypatch) -> None:
         calls.append(argv)
         return _FakeProcess()
 
-    async def exercise() -> None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        ctrl = AlsaVolumeController(card=1, element="Digital")
-        await ctrl.set_state(50, muted=True)
-
-    asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    ctrl = AlsaVolumeController(card=1, element="Digital")
+    await ctrl.set_state(50, muted=True)
     assert calls == [("amixer", "-M", "-c", "1", "sset", "Digital", "playback", "50%", "mute")]
 
 
 # -- AlsaVolumeController.get_state ------------------------------------------
 
 
-def test_get_state_parses_amixer_output(monkeypatch) -> None:
+async def test_get_state_parses_amixer_output(monkeypatch) -> None:
     """get_state parses volume percentage and on/off from amixer sget."""
     amixer_output = (
         "Simple mixer control 'Digital',0\n"
@@ -260,17 +225,14 @@ def test_get_state_parses_amixer_output(monkeypatch) -> None:
         "  Front Right: Playback 155 [74%] [-15.60dB] [on]\n"
     )
 
-    async def exercise() -> tuple[int, bool]:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(amixer_output))
-        ctrl = AlsaVolumeController(card=1, element="Digital")
-        return await ctrl.get_state()
-
-    volume, muted = asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(amixer_output))
+    ctrl = AlsaVolumeController(card=1, element="Digital")
+    volume, muted = await ctrl.get_state()
     assert volume == 74
     assert muted is False
 
 
-def test_get_state_detects_muted(monkeypatch) -> None:
+async def test_get_state_detects_muted(monkeypatch) -> None:
     """get_state detects [off] as muted."""
     amixer_output = (
         "Simple mixer control 'PCM',0\n"
@@ -280,17 +242,14 @@ def test_get_state_detects_muted(monkeypatch) -> None:
         "  Mono: Playback -4919 [50%] [-49.19dB] [off]\n"
     )
 
-    async def exercise() -> tuple[int, bool]:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(amixer_output))
-        ctrl = AlsaVolumeController(card=0, element="PCM")
-        return await ctrl.get_state()
-
-    volume, muted = asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(amixer_output))
+    ctrl = AlsaVolumeController(card=0, element="PCM")
+    volume, muted = await ctrl.get_state()
     assert volume == 50
     assert muted is True
 
 
-def test_get_state_mono_channel(monkeypatch) -> None:
+async def test_get_state_mono_channel(monkeypatch) -> None:
     """get_state handles mono devices (single channel line)."""
     amixer_output = (
         "Simple mixer control 'PCM',0\n"
@@ -300,12 +259,9 @@ def test_get_state_mono_channel(monkeypatch) -> None:
         "  Mono: Playback 0 [96%] [0.00dB] [on]\n"
     )
 
-    async def exercise() -> tuple[int, bool]:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(amixer_output))
-        ctrl = AlsaVolumeController(card=0, element="PCM")
-        return await ctrl.get_state()
-
-    volume, muted = asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(amixer_output))
+    ctrl = AlsaVolumeController(card=0, element="PCM")
+    volume, muted = await ctrl.get_state()
     assert volume == 96
     assert muted is False
 
@@ -313,7 +269,7 @@ def test_get_state_mono_channel(monkeypatch) -> None:
 # -- AlsaVolumeController.start_monitoring ------------------------------------
 
 
-def test_monitoring_detects_external_change(monkeypatch) -> None:
+async def test_monitoring_detects_external_change(monkeypatch) -> None:
     """Monitor loop calls callback when volume changes between polls."""
     got_callback = asyncio.Event()
     callback_received: list[tuple[int, bool]] = []
@@ -329,34 +285,30 @@ def test_monitoring_detects_external_change(monkeypatch) -> None:
         callback_received.append((volume, muted))
         got_callback.set()
 
-    async def exercise() -> None:
-        monkeypatch.setattr(_alsa_mod, "_POLL_INTERVAL_S", 0.0)
-        ctrl = AlsaVolumeController(card=0, element="PCM")
+    monkeypatch.setattr(_alsa_mod, "_POLL_INTERVAL_S", 0.0)
+    ctrl = AlsaVolumeController(card=0, element="PCM")
 
-        async def fake_get() -> tuple[int, bool]:
-            try:
-                return next(state_iter)
-            except StopIteration:
-                # Keep returning last state after sequence ends
-                return (75, False)
-
-        ctrl.get_state = fake_get  # type: ignore[assignment]
-
-        await ctrl.start_monitoring(on_change)
+    async def fake_get() -> tuple[int, bool]:
         try:
-            await asyncio.wait_for(got_callback.wait(), timeout=2.0)
-        finally:
-            await ctrl.stop_monitoring()
+            return next(state_iter)
+        except StopIteration:
+            return (75, False)
 
-        assert callback_received == [(75, False)]
+    ctrl.get_state = fake_get  # type: ignore[assignment]
 
-    asyncio.run(exercise())
+    await ctrl.start_monitoring(on_change)
+    try:
+        await asyncio.wait_for(got_callback.wait(), timeout=2.0)
+    finally:
+        await ctrl.stop_monitoring()
+
+    assert callback_received == [(75, False)]
 
 
 # -- async_check_alsa_available -----------------------------------------------
 
 
-def test_alsa_available_for_hw_device_with_mixer(monkeypatch) -> None:
+async def test_alsa_available_for_hw_device_with_mixer(monkeypatch) -> None:
     """Returns (card, element) for a hw: device with mixer controls."""
     scontrols = "Simple mixer control 'Digital',0\n"
     sget_pvolume = "  Capabilities: pvolume pswitch\n"
@@ -366,34 +318,26 @@ def test_alsa_available_for_hw_device_with_mixer(monkeypatch) -> None:
             return _FakeProcess(stdout=scontrols.encode())
         return _FakeProcess(stdout=sget_pvolume.encode())
 
-    async def exercise() -> tuple[int, str] | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        device = SimpleNamespace(name="HiFiBerry DAC+: pcm512x (hw:1,0)", is_default=False)
-        return await async_check_alsa_available(device)
-
-    result = asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(_alsa_mod, "AVAILABLE", True)
+    device = SimpleNamespace(name="HiFiBerry DAC+: pcm512x (hw:1,0)", is_default=False)
+    result = await async_check_alsa_available(device)
     assert result == (1, "Digital")
 
 
-def test_alsa_not_available_for_virtual_device() -> None:
+async def test_alsa_not_available_for_virtual_device(monkeypatch) -> None:
     """Returns None for virtual devices (no hw: in name)."""
-
-    async def exercise() -> tuple[int, str] | None:
-        device = SimpleNamespace(name="pipewire", is_default=False)
-        return await async_check_alsa_available(device)
-
-    assert asyncio.run(exercise()) is None
+    monkeypatch.setattr(_alsa_mod, "AVAILABLE", True)
+    device = SimpleNamespace(name="pipewire", is_default=False)
+    assert await async_check_alsa_available(device) is None
 
 
-def test_alsa_not_available_when_no_mixer_controls(monkeypatch) -> None:
+async def test_alsa_not_available_when_no_mixer_controls(monkeypatch) -> None:
     """Returns None when card has no mixer elements (PCM5102A)."""
-
-    async def exercise() -> tuple[int, str] | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(""))
-        device = SimpleNamespace(name="DAC Zero (hw:2,0)", is_default=False)
-        return await async_check_alsa_available(device)
-
-    assert asyncio.run(exercise()) is None
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _amixer_exec(""))
+    monkeypatch.setattr(_alsa_mod, "AVAILABLE", True)
+    device = SimpleNamespace(name="DAC Zero (hw:2,0)", is_default=False)
+    assert await async_check_alsa_available(device) is None
 
 
 # -- Simulated HiFiBerry DAC+ HAT scenario -----------------------------------
@@ -425,7 +369,7 @@ _HIFIBERRY_SGET_74 = (
 _HIFIBERRY_DEVICE_NAME = "snd_rpi_hifiberry_dacplus: HiFiBerry DAC+ HiFi pcm512x-hifi-0 (hw:1,0)"
 
 
-def test_hifiberry_dac_discovery(monkeypatch) -> None:
+async def test_hifiberry_dac_discovery(monkeypatch) -> None:
     """Full discovery flow for a HiFiBerry DAC+ HAT on card 1."""
     sget_with_pvolume = "  Capabilities: pvolume pswitch\n"
     sget_without_pvolume = "  Capabilities: enum\n"
@@ -433,51 +377,42 @@ def test_hifiberry_dac_discovery(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=_HIFIBERRY_SCONTROLS.encode())
-        # Both Analogue and Digital have pvolume on real hardware.
         if "Analogue" in argv or "Digital" in argv:
             return _FakeProcess(stdout=sget_with_pvolume.encode())
         return _FakeProcess(stdout=sget_without_pvolume.encode())
 
-    async def exercise() -> tuple[int, str] | None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        device = SimpleNamespace(name=_HIFIBERRY_DEVICE_NAME, is_default=False)
-        return await async_check_alsa_available(device)
-
-    result = asyncio.run(exercise())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(_alsa_mod, "AVAILABLE", True)
+    device = SimpleNamespace(name=_HIFIBERRY_DEVICE_NAME, is_default=False)
+    result = await async_check_alsa_available(device)
     assert result == (1, "Digital")
 
 
-def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
+async def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
     """Set and read volume on a simulated HiFiBerry DAC+ HAT."""
     calls: list[tuple[str, ...]] = []
 
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         calls.append(argv)
-        # Return sget-style output for get_state calls
         return _FakeProcess(stdout=_HIFIBERRY_SGET_74.encode())
 
-    async def exercise() -> None:
-        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-        ctrl = AlsaVolumeController(card=1, element="Digital")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    ctrl = AlsaVolumeController(card=1, element="Digital")
 
-        # Server sends volume command -> controller sets ALSA mixer
-        await ctrl.set_state(74, muted=False)
-        assert calls[-1] == (
-            "amixer",
-            "-M",
-            "-c",
-            "1",
-            "sset",
-            "Digital",
-            "playback",
-            "74%",
-            "unmute",
-        )
+    await ctrl.set_state(74, muted=False)
+    assert calls[-1] == (
+        "amixer",
+        "-M",
+        "-c",
+        "1",
+        "sset",
+        "Digital",
+        "playback",
+        "74%",
+        "unmute",
+    )
 
-        # Read back the volume
-        volume, muted = await ctrl.get_state()
-        assert calls[-1] == ("amixer", "-M", "-c", "1", "sget", "Digital")
-        assert volume == 74
-        assert muted is False
-
-    asyncio.run(exercise())
+    volume, muted = await ctrl.get_state()
+    assert calls[-1] == ("amixer", "-M", "-c", "1", "sget", "Digital")
+    assert volume == 74
+    assert muted is False

--- a/tests/test_alsa_volume.py
+++ b/tests/test_alsa_volume.py
@@ -81,6 +81,8 @@ async def test_find_mixer_element_digital(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=scontrols.encode())
+        # On real HiFiBerry DAC+ (PCM5122), both Analogue and Digital
+        # have pvolume. The preference logic should pick Digital.
         if "Analogue" in argv or "Digital" in argv:
             return _FakeProcess(stdout=sget_with_pvolume.encode())
         return _FakeProcess(stdout=sget_without_pvolume.encode())
@@ -160,6 +162,7 @@ async def test_find_mixer_element_capability_scan_fallback(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=scontrols_output.encode())
+        # sget calls: return capabilities based on element name
         if "Mic" in argv:
             return _FakeProcess(stdout=sget_mic.encode())
         return _FakeProcess(stdout=sget_output.encode())
@@ -294,6 +297,7 @@ async def test_monitoring_detects_external_change(monkeypatch) -> None:
         try:
             return next(state_iter)
         except StopIteration:
+            # Keep returning last state after sequence ends
             return (75, False)
 
     ctrl.get_state = fake_get  # type: ignore[assignment]
@@ -379,6 +383,7 @@ async def test_hifiberry_dac_discovery(monkeypatch) -> None:
     async def fake_exec(*argv: object, **kwargs: object) -> _FakeProcess:
         if "scontrols" in argv:
             return _FakeProcess(stdout=_HIFIBERRY_SCONTROLS.encode())
+        # Both Analogue and Digital have pvolume on real hardware.
         if "Analogue" in argv or "Digital" in argv:
             return _FakeProcess(stdout=sget_with_pvolume.encode())
         return _FakeProcess(stdout=sget_without_pvolume.encode())
@@ -401,6 +406,7 @@ async def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
     ctrl = AlsaVolumeController(card=1, element="Digital")
 
+    # Server sends volume command -> controller sets ALSA mixer
     await ctrl.set_state(74, muted=False)
     assert calls[-1] == (
         "amixer",
@@ -414,6 +420,7 @@ async def test_hifiberry_dac_set_and_get_volume(monkeypatch) -> None:
         "unmute",
     )
 
+    # Read back the volume
     volume, muted = await ctrl.get_state()
     assert calls[-1] == ("amixer", "-M", "-c", "1", "sget", "Digital")
     assert volume == 74


### PR DESCRIPTION
## Summary
- Add `pytest-asyncio` dependency and configure `asyncio_mode = "auto"` so async test functions are handled natively by pytest
- Convert all async tests in `test_alsa_volume.py` from the `async def exercise() / asyncio.run()` workaround to proper `async def test_*` functions
- Monkeypatch `AVAILABLE` in `async_check_alsa_available` tests so they exercise the actual logic on non-Linux platforms (previously they silently short-circuited to `None`)

## Test plan
- [x] All 22 tests pass: `uv run python -m pytest tests/test_alsa_volume.py -v`
- [x] Pre-commit checks pass: `uv run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)