### PR TITLE
Drop audio chunk gracefully when worker isn't running

### DIFF
--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -344,6 +344,7 @@ class AudioStreamHandler:
         self._client_unsubscribers: list[Callable[[], None]] = []
 
         self._volume_controller: VolumeController | None = volume_controller
+        self._chunks_dropping = False
 
     @property
     def volume(self) -> int:
@@ -478,7 +479,11 @@ class AudioStreamHandler:
         """Handle incoming audio chunks by enqueueing them to the sync worker."""
         worker = self._audio_worker
         if worker is None or not worker.is_running():
-            raise RuntimeError("Audio worker is not running")
+            if not self._chunks_dropping:
+                logger.debug("Audio chunks dropping: worker not running")
+                self._chunks_dropping = True
+            return
+        self._chunks_dropping = False
 
         pcm_format = fmt.pcm_format
         if self._current_format != fmt:


### PR DESCRIPTION
During connection transitions, audio chunks can arrive while the worker is stopped. Replace the `RuntimeError` with a rate-limited debug log and silent drop, since this is a benign race.

Log fires once per dropping window and resets when chunks flow again, avoiding noise under `--debug`.

Split out from #202.