### PR TITLE
Fix audio underflow on stream start by buffering before playback

### DIFF
--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -1225,8 +1225,11 @@ class AudioPlayer:
             # Update expected position for next chunk
             self._expected_next_timestamp = server_timestamp_us + chunk_duration_us
 
-        # Start stream immediately when first chunk arrives
-        if not self._stream_started and self._queue.qsize() > 0 and self._stream is not None:
+        # Start stream once we have enough buffer to avoid immediate underflow
+        if not self._stream_started and self._stream is not None and (
+            self._queued_duration_us >= self._MIN_BUFFER_DURATION_US
+            or self._queue.qsize() >= self._MIN_CHUNKS_TO_START
+        ):
             self._stream_started = True
             self._stream_executor.submit(self._call_stream, self._stream.start)
             logger.info(


### PR DESCRIPTION
## Problem

The ALSA stream starts immediately when the first audio chunk arrives (`queue.qsize() > 0`), with only ~25ms of audio buffered. The PortAudio callback drains this single chunk before the next one arrives over the network, causing an immediate underflow.

This triggers a clear/re-anchor cycle that can cascade into repeated underflows:

```
INFO:sendspin.audio:Stream STARTED: 1 chunks, 0.03 seconds buffered
INFO:sendspin.audio:Sync error 514.3 ms too large; scheduling reanchor
WARNING:sendspin.audio:Audio underflow detected; requesting re-anchor
INFO:sendspin.audio:Cleared audio queue after underflow (deferred from audio thread)
```

This is especially problematic with USB audio devices that have larger period sizes (2048 frames / ~42ms at 48kHz), where the output latency alone exceeds the buffered audio duration.

## Fix

Wait until sufficient audio is buffered before starting the stream, using the existing `_MIN_BUFFER_DURATION_US` (200ms) and `_MIN_CHUNKS_TO_START` (16) constants:

```python
# Before (starts with ~25ms buffer):
if not self._stream_started and self._queue.qsize() > 0 and self._stream is not None:

# After (waits for 200ms or 16 chunks):
if not self._stream_started and self._stream is not None and (
    self._queued_duration_us >= self._MIN_BUFFER_DURATION_US
    or self._queue.qsize() >= self._MIN_CHUNKS_TO_START
):
```

This adds ~200ms of initial latency but eliminates the underflow/re-anchor cascade. After the fix:

```
INFO:sendspin.audio:Stream STARTED: 8 chunks, 0.20 seconds buffered
```

## Environment

- sendspin 7.0.0
- Raspberry Pi 5 (aarch64)
- USB audio: Wondom GAB8 8-channel amplifiers (period_size=2048, buffer_size=16384)
- PortAudio V19.6.0-devel, MMAP_INTERLEAVED access