### PR TITLE
Fix ALSA device not closing (#233)

### DIFF
--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -330,6 +330,19 @@ class AudioPlayer:
         self._close_stream()
         self._stream_executor.shutdown(wait=True)
 
+    def close_stream(self) -> None:
+        """Close the audio stream and release the audio device.
+
+        Unlike clear(), which only stops the stream (leaving the device FD open),
+        this fully closes the PortAudio stream so the audio device is released.
+        Call when the server signals end-of-stream; the stream will be recreated
+        by set_format() when the next track begins.
+        """
+        if self._closed:
+            return
+        self._stream_started = False
+        self._close_stream()
+
     def clear(self) -> None:
         """Drop all queued audio chunks."""
         if self._closed:

--- a/sendspin/audio.py
+++ b/sendspin/audio.py
@@ -331,16 +331,16 @@ class AudioPlayer:
         self._stream_executor.shutdown(wait=True)
 
     def close_stream(self) -> None:
-        """Close the audio stream and release the audio device.
+        """Drop queued audio and fully close the stream to release the device.
 
         Unlike clear(), which only stops the stream (leaving the device FD open),
-        this fully closes the PortAudio stream so the audio device is released.
-        Call when the server signals end-of-stream; the stream will be recreated
-        by set_format() when the next track begins.
+        this fully closes the PortAudio stream. Call when the server signals
+        end-of-stream; the stream will be recreated by set_format() when the
+        next track begins.
         """
         if self._closed:
             return
-        self._stream_started = False
+        self.clear()
         self._close_stream()
 
     def clear(self) -> None:

--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -61,8 +61,18 @@ class _StopWorkItem:
     """Stop signal for the synchronous audio worker."""
 
 
+@dataclass(slots=True)
+class _CloseStreamWorkItem:
+    """Close the audio stream and release the audio device on stream end."""
+
+
 type _AudioWorkItem = (
-    _ChunkWorkItem | _ClearWorkItem | _SetVolumeWorkItem | _DelayChangeWorkItem | _StopWorkItem
+    _ChunkWorkItem
+    | _ClearWorkItem
+    | _SetVolumeWorkItem
+    | _DelayChangeWorkItem
+    | _StopWorkItem
+    | _CloseStreamWorkItem
 )
 
 
@@ -118,6 +128,10 @@ class _AudioSyncWorker:
     def clear(self) -> None:
         """Clear queued audio on worker."""
         self._enqueue(_ClearWorkItem())
+
+    def close_stream(self) -> None:
+        """Clear queued audio and close the stream to release the audio device."""
+        self._enqueue(_CloseStreamWorkItem())
 
     def notify_delay_change(self, delta_us: int) -> None:
         """Notify the worker that static delay changed."""
@@ -198,6 +212,12 @@ class _AudioSyncWorker:
                 player.clear()
                 continue
 
+            if item_type is _CloseStreamWorkItem:
+                player.clear()
+                player.close_stream()
+                current_format = None  # force set_format() when next track begins
+                continue
+
             if item_type is _DelayChangeWorkItem:
                 player.apply_delay_change(cast(_DelayChangeWorkItem, item).delta_us)
                 continue
@@ -218,6 +238,7 @@ class _AudioSyncWorker:
                 buffered_chunks: list[_ChunkWorkItem] = [chunk_item]
                 drained = player.is_drained()
                 deadline = time.monotonic() + 60.0
+                close_requested = False
 
                 while not drained and time.monotonic() < deadline:
                     try:
@@ -235,6 +256,13 @@ class _AudioSyncWorker:
                         buffered_chunks.clear()
                         drained = True
                         break
+                    if drain_type is _CloseStreamWorkItem:
+                        player.clear()
+                        player.close_stream()
+                        buffered_chunks.clear()
+                        drained = True
+                        close_requested = True
+                        break
                     if drain_type is _SetVolumeWorkItem:
                         vol = cast(_SetVolumeWorkItem, drain_item)
                         software_volume = vol.volume
@@ -251,6 +279,10 @@ class _AudioSyncWorker:
                 if not drained:
                     logger.warning("Drain timeout during format switch; forcing clear")
                     player.clear()
+
+                if close_requested:
+                    current_format = None
+                    continue
 
                 current_format = fmt
                 player.set_format(fmt, device=self._audio_device)
@@ -473,6 +505,12 @@ class AudioStreamHandler:
         if worker is not None and worker.is_running():
             worker.clear()
 
+    def _close_stream_audio_worker(self) -> None:
+        """Clear queue and fully close the stream to release the audio device."""
+        worker = self._audio_worker
+        if worker is not None and worker.is_running():
+            worker.close_stream()
+
     def _on_audio_chunk(
         self, server_timestamp_us: int, audio_data: bytes | bytearray, fmt: AudioFormat
     ) -> None:
@@ -515,11 +553,11 @@ class AudioStreamHandler:
                 self._on_event("start")
 
     def _on_stream_end(self, roles: list[str] | None) -> None:
-        """Handle stream end by clearing audio queue."""
+        """Handle stream end by closing the audio stream to release the audio device."""
         if roles is not None and Roles.PLAYER.value not in roles:
             return
 
-        self._clear_audio_worker()
+        self._close_stream_audio_worker()
 
         if self._stream_active:
             self._stream_active = False

--- a/sendspin/audio_connector.py
+++ b/sendspin/audio_connector.py
@@ -213,7 +213,6 @@ class _AudioSyncWorker:
                 continue
 
             if item_type is _CloseStreamWorkItem:
-                player.clear()
                 player.close_stream()
                 current_format = None  # force set_format() when next track begins
                 continue
@@ -251,17 +250,14 @@ class _AudioSyncWorker:
                     if drain_type is _StopWorkItem:
                         player.stop()
                         return
-                    if drain_type is _ClearWorkItem:
-                        player.clear()
+                    if drain_type is _ClearWorkItem or drain_type is _CloseStreamWorkItem:
+                        if drain_type is _CloseStreamWorkItem:
+                            player.close_stream()
+                            close_requested = True
+                        else:
+                            player.clear()
                         buffered_chunks.clear()
                         drained = True
-                        break
-                    if drain_type is _CloseStreamWorkItem:
-                        player.clear()
-                        player.close_stream()
-                        buffered_chunks.clear()
-                        drained = True
-                        close_requested = True
                         break
                     if drain_type is _SetVolumeWorkItem:
                         vol = cast(_SetVolumeWorkItem, drain_item)
@@ -505,12 +501,6 @@ class AudioStreamHandler:
         if worker is not None and worker.is_running():
             worker.clear()
 
-    def _close_stream_audio_worker(self) -> None:
-        """Clear queue and fully close the stream to release the audio device."""
-        worker = self._audio_worker
-        if worker is not None and worker.is_running():
-            worker.close_stream()
-
     def _on_audio_chunk(
         self, server_timestamp_us: int, audio_data: bytes | bytearray, fmt: AudioFormat
     ) -> None:
@@ -557,7 +547,9 @@ class AudioStreamHandler:
         if roles is not None and Roles.PLAYER.value not in roles:
             return
 
-        self._close_stream_audio_worker()
+        worker = self._audio_worker
+        if worker is not None and worker.is_running():
+            worker.close_stream()
 
         if self._stream_active:
             self._stream_active = False

--- a/tests/test_audio_connector.py
+++ b/tests/test_audio_connector.py
@@ -24,6 +24,8 @@ class _FakeWorker:
         self.volume = volume
         self.muted = muted
         self.running = False
+        self.cleared = False
+        self.stream_closed = False
         self.submitted: list[tuple[int, bytes | bytearray, object]] = []
         _FakeWorker.instances.append(self)
 
@@ -41,7 +43,10 @@ class _FakeWorker:
         self.submitted.append((server_timestamp_us, audio_data, fmt))
 
     def clear(self) -> None:
-        return
+        self.cleared = True
+
+    def close_stream(self) -> None:
+        self.stream_closed = True
 
     def set_volume(self, volume: int, *, muted: bool) -> None:
         self.volume = volume
@@ -247,3 +252,25 @@ def test_external_volume_controller_updates_logical_volume(tmp_path) -> None:
         assert changes == [(41, False)]
 
     asyncio.run(exercise())
+
+
+def test_stream_end_closes_stream_not_just_clears(monkeypatch) -> None:
+    """stream_end must fully close the stream (release the device), not just clear."""
+    monkeypatch.setattr(audio_connector, "_AudioSyncWorker", _FakeWorker)
+    _FakeWorker.instances.clear()
+
+    handler = AudioStreamHandler(
+        audio_device=SimpleNamespace(index=0, name="Fake Device"),
+        volume=10,
+        muted=False,
+    )
+    client = _FakeClient()
+    handler.attach_client(client)
+
+    worker = _FakeWorker.instances[0]
+    assert not worker.stream_closed
+
+    handler._on_stream_end(None)
+
+    assert worker.stream_closed, "_on_stream_end must call close_stream(), not just clear()"
+    assert not worker.cleared, "_on_stream_end must not call clear() separately"


### PR DESCRIPTION
This PR fixes the issue of ALSA staying open after stream end (#233), by calling the existing `AudioPlayer::_close_stream` from `AudioStreamHandler::_on_stream_end`.

Tested on Linux, with this change the ALSA stream immediatecly closes on pause, and resumes on play. Haven't tested any othere audio backends.