### PR TITLE
Fix wrong audio sync delta after server-driven delay change

### DIFF
--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -72,9 +72,10 @@ class SendspinDaemon:
         self._audio_handler: AudioStreamHandler | None = None
         self._settings = args.settings
         self._mpris: SendspinMpris | None = None
-        # Currently-applied static delay (mirror of client._static_delay_us). Tracked
-        # separately from settings because CLI overrides aren't persisted to settings,
-        # so settings.static_delay_ms can lag the value actually given to the client.
+        # Currently-applied static delay in milliseconds, mirroring
+        # `SendspinClient.static_delay_ms`. Tracked separately from settings
+        # because CLI overrides aren't persisted to settings, so
+        # `settings.static_delay_ms` can lag the value actually given to the client.
         self._static_delay_ms: float = 0.0
         self._connection_lock: asyncio.Lock | None = None
         self._server_url: str | None = None

--- a/sendspin/daemon/daemon.py
+++ b/sendspin/daemon/daemon.py
@@ -72,13 +72,16 @@ class SendspinDaemon:
         self._audio_handler: AudioStreamHandler | None = None
         self._settings = args.settings
         self._mpris: SendspinMpris | None = None
+        # Currently-applied static delay (mirror of client._static_delay_us). Tracked
+        # separately from settings because CLI overrides aren't persisted to settings,
+        # so settings.static_delay_ms can lag the value actually given to the client.
         self._static_delay_ms: float = 0.0
         self._connection_lock: asyncio.Lock | None = None
         self._server_url: str | None = None
         self._group_update_unsubscribe: Callable[[], None] | None = None
         self._server_command_unsubscribe: Callable[[], None] | None = None
 
-    def _create_client(self, static_delay_ms: float = 0.0) -> SendspinClient:
+    def _create_client(self) -> SendspinClient:
         """Create a new SendspinClient instance."""
         assert self._audio_handler is not None
         client_roles = [Roles.PLAYER]
@@ -103,7 +106,7 @@ class SendspinDaemon:
                 buffer_capacity=32_000_000,
                 supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
             ),
-            static_delay_ms=static_delay_ms,
+            static_delay_ms=self._static_delay_ms,
             state_supported_commands=[PlayerCommand.SET_STATIC_DELAY],
             initial_volume=self._audio_handler.volume,
             initial_muted=self._audio_handler.muted,
@@ -133,6 +136,7 @@ class SendspinDaemon:
             if self._args.static_delay_ms is not None
             else self._settings.static_delay_ms
         )
+        self._static_delay_ms = max(0.0, min(5000.0, delay))
 
         self._audio_handler = AudioStreamHandler(
             audio_device=self._args.audio_device,
@@ -149,10 +153,10 @@ class SendspinDaemon:
         try:
             if self._args.url is not None:
                 # Client-initiated connection mode
-                await self._run_client_initiated(delay)
+                await self._run_client_initiated()
             else:
                 # Server-initiated connection mode (listen for incoming connections)
-                await self._run_server_initiated(delay)
+                await self._run_server_initiated()
         except asyncio.CancelledError:
             logger.debug("Daemon cancelled")
         finally:
@@ -181,11 +185,11 @@ class SendspinDaemon:
         if not self._audio_handler.uses_external_volume_controller:
             self._settings.update(player_volume=volume, player_muted=muted)
 
-    async def _run_client_initiated(self, static_delay_ms: float) -> None:
+    async def _run_client_initiated(self) -> None:
         """Run in client-initiated mode, connecting to a specific URL."""
         assert self._args.url is not None
         assert self._audio_handler is not None
-        self._client = self._create_client(static_delay_ms)
+        self._client = self._create_client()
         if MPRIS_AVAILABLE and self._args.use_mpris:
             self._mpris = SendspinMpris(self._client)
             self._mpris.start()
@@ -196,14 +200,13 @@ class SendspinDaemon:
         )
         await self._connection_loop(self._args.url)
 
-    async def _run_server_initiated(self, static_delay_ms: float) -> None:
+    async def _run_server_initiated(self) -> None:
         """Run in server-initiated mode, listening for incoming connections."""
         logger.info(
             "Listening for server connections on port %d (mDNS: _sendspin._tcp.local.)",
             self._args.listen_port,
         )
 
-        self._static_delay_ms = static_delay_ms  # Store for use in connection handler
         self._connection_lock = asyncio.Lock()
 
         self._listener = ClientListener(
@@ -287,7 +290,7 @@ class SendspinDaemon:
 
             # Per spec: always complete the handshake before deciding which
             # server to keep.
-            client = self._create_client(self._static_delay_ms)
+            client = self._create_client()
 
             try:
                 await client.attach_websocket(ws)
@@ -410,11 +413,12 @@ class SendspinDaemon:
             # Client library already applied the delay change;
             # notify audio worker so sync correction adjusts timing gradually
             assert self._client is not None
-            old_delay_ms = self._settings.static_delay_ms
-            delta_us = int((self._client.static_delay_ms - old_delay_ms) * 1000)
+            new_delay_ms = self._client.static_delay_ms
+            delta_us = int((new_delay_ms - self._static_delay_ms) * 1000)
             if delta_us != 0:
                 self._audio_handler.notify_delay_change(delta_us)
-            self._settings.update(static_delay_ms=self._client.static_delay_ms)
+            self._static_delay_ms = new_delay_ms
+            self._settings.update(static_delay_ms=new_delay_ms)
             logger.info("Server set delay: %dms", player_cmd.static_delay_ms)
 
     def _handle_format_change(

--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -253,9 +253,10 @@ class SendspinApp:
         self._visualizer_handler: VisualizerHandler | None = None
         self._settings = args.settings
         self._visualizer_enabled: bool = args.settings.visualizer
-        # Currently-applied static delay (canonical local mirror of client._static_delay_us).
-        # Tracked separately from settings because CLI overrides aren't persisted to settings,
-        # so settings.static_delay_ms can lag the value actually given to the client.
+        # Currently-applied static delay in milliseconds, mirroring
+        # `SendspinClient.static_delay_ms`. Tracked separately from settings
+        # because CLI overrides aren't persisted to settings, so
+        # `settings.static_delay_ms` can lag the value actually given to the client.
         self._applied_delay_ms: float = 0.0
         interfaces = [args.interface] if args.interface else None
         self._discovery = ServiceDiscovery(interfaces=interfaces)
@@ -405,7 +406,7 @@ class SendspinApp:
             await self._audio_handler.start_volume_monitor()
 
             self._ui = SendspinUI(
-                delay,
+                self._applied_delay_ms,
                 player_volume=self._audio_handler.volume,
                 player_muted=self._audio_handler.muted,
                 use_external_volume=self._audio_handler.uses_external_volume_controller,

--- a/sendspin/tui/app.py
+++ b/sendspin/tui/app.py
@@ -253,6 +253,10 @@ class SendspinApp:
         self._visualizer_handler: VisualizerHandler | None = None
         self._settings = args.settings
         self._visualizer_enabled: bool = args.settings.visualizer
+        # Currently-applied static delay (canonical local mirror of client._static_delay_us).
+        # Tracked separately from settings because CLI overrides aren't persisted to settings,
+        # so settings.static_delay_ms can lag the value actually given to the client.
+        self._applied_delay_ms: float = 0.0
         interfaces = [args.interface] if args.interface else None
         self._discovery = ServiceDiscovery(interfaces=interfaces)
         self._connection_manager = ConnectionManager(self._discovery)
@@ -286,11 +290,6 @@ class SendspinApp:
             roles.append(Roles.VISUALIZER)
 
         assert self._audio_handler is not None
-        delay = (
-            args.static_delay_ms
-            if args.static_delay_ms is not None
-            else self._settings.static_delay_ms
-        )
 
         return SendspinClient(
             client_id=args.client_id,
@@ -306,7 +305,7 @@ class SendspinApp:
                 supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
             ),
             visualizer_support=visualizer_support,
-            static_delay_ms=delay,
+            static_delay_ms=self._applied_delay_ms,
             state_supported_commands=[PlayerCommand.SET_STATIC_DELAY],
             initial_volume=self._audio_handler.volume,
             initial_muted=self._audio_handler.muted,
@@ -378,6 +377,7 @@ class SendspinApp:
                 if args.static_delay_ms is not None
                 else self._settings.static_delay_ms
             )
+            self._applied_delay_ms = max(0.0, min(5000.0, delay))
 
             self._audio_handler = AudioStreamHandler(
                 audio_device=args.audio_device,
@@ -431,6 +431,7 @@ class SendspinApp:
                     self._on_server_selected,
                     request_shutdown,
                     on_toggle_visualizer=self._toggle_visualizer,
+                    on_delay_changed=self._set_applied_delay,
                 )
             )
 
@@ -780,12 +781,13 @@ class SendspinApp:
             # notify audio worker so sync correction adjusts timing gradually
             assert self._client is not None
             assert self._audio_handler is not None
-            old_delay_ms = self._settings.static_delay_ms
-            delta_us = int((self._client.static_delay_ms - old_delay_ms) * 1000)
+            new_delay_ms = self._client.static_delay_ms
+            delta_us = int((new_delay_ms - self._applied_delay_ms) * 1000)
             if delta_us != 0:
                 self._audio_handler.notify_delay_change(delta_us)
-            self._ui.set_delay(self._client.static_delay_ms)
-            self._settings.update(static_delay_ms=self._client.static_delay_ms)
+            self._applied_delay_ms = new_delay_ms
+            self._ui.set_delay(new_delay_ms)
+            self._settings.update(static_delay_ms=new_delay_ms)
             self._ui.add_event(f"Server set delay: {player_cmd.static_delay_ms}ms")
 
     def _handle_format_change(
@@ -794,6 +796,10 @@ class SendspinApp:
         """Handle audio format changes by updating the UI."""
         assert self._ui is not None
         self._ui.set_audio_format(codec, sample_rate, bit_depth, channels)
+
+    def _set_applied_delay(self, delay_ms: float) -> None:
+        """Mirror the locally-applied static delay so SET_STATIC_DELAY deltas stay correct."""
+        self._applied_delay_ms = delay_ms
 
     async def _toggle_visualizer(self) -> None:
         """Toggle the visualizer on/off, reconnecting with updated roles."""

--- a/sendspin/tui/keyboard.py
+++ b/sendspin/tui/keyboard.py
@@ -155,6 +155,9 @@ async def keyboard_loop(
         on_server_selected: Async callback when a server is selected.
         request_shutdown: Callback to request application shutdown.
         on_toggle_visualizer: Async callback to toggle the visualizer.
+        on_delay_changed: Optional callback invoked with the new static delay
+            (milliseconds) after a local adjust, so the app can keep its
+            applied-delay tracker in sync.
     """
     handler = CommandHandler(
         get_client,

--- a/sendspin/tui/keyboard.py
+++ b/sendspin/tui/keyboard.py
@@ -32,6 +32,7 @@ class CommandHandler:
         audio_handler: AudioStreamHandler,
         ui: SendspinUI,
         settings: ClientSettings,
+        on_delay_changed: Callable[[float], None] | None = None,
     ) -> None:
         """Initialize the command handler."""
         self._get_client = get_client
@@ -39,6 +40,7 @@ class CommandHandler:
         self._audio_handler = audio_handler
         self._ui = ui
         self._settings = settings
+        self._on_delay_changed = on_delay_changed
 
     async def send_media_command(self, command: MediaCommand) -> None:
         """Send a media command with validation."""
@@ -120,6 +122,8 @@ class CommandHandler:
             self._audio_handler.notify_delay_change(actual_delta_us)
         self._ui.set_delay(client.static_delay_ms)
         self._settings.update(static_delay_ms=client.static_delay_ms)
+        if self._on_delay_changed is not None:
+            self._on_delay_changed(client.static_delay_ms)
         self._audio_handler.send_player_volume()
 
     def close_server_selector(self) -> None:
@@ -137,6 +141,7 @@ async def keyboard_loop(
     on_server_selected: Callable[[], Awaitable[None]],
     request_shutdown: Callable[[], None],
     on_toggle_visualizer: Callable[[], Awaitable[None]],
+    on_delay_changed: Callable[[float], None] | None = None,
 ) -> None:
     """Run the keyboard input loop.
 
@@ -151,7 +156,14 @@ async def keyboard_loop(
         request_shutdown: Callback to request application shutdown.
         on_toggle_visualizer: Async callback to toggle the visualizer.
     """
-    handler = CommandHandler(get_client, state, audio_handler, ui, settings)
+    handler = CommandHandler(
+        get_client,
+        state,
+        audio_handler,
+        ui,
+        settings,
+        on_delay_changed=on_delay_changed,
+    )
 
     # Key dispatch table: key -> (highlight_name | None, action)
     # Actions can be sync or async. For keys that need case-insensitive matching, use lowercase.

--- a/tests/daemon/test_daemon.py
+++ b/tests/daemon/test_daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,11 +15,15 @@ class _FakeAudioHandler:
         self.volume = volume
         self.muted = muted
         self.calls: list[tuple[int, bool]] = []
+        self.delay_changes: list[int] = []
 
     def set_volume(self, volume: int, *, muted: bool) -> None:
         self.calls.append((volume, muted))
         self.volume = volume
         self.muted = muted
+
+    def notify_delay_change(self, delta_us: int) -> None:
+        self.delay_changes.append(delta_us)
 
 
 def _make_daemon(tmp_path: Path, *, settings_volume: int, settings_muted: bool) -> SendspinDaemon:
@@ -61,3 +66,37 @@ def test_mute_command_uses_audio_handler_volume_state_for_external_volume(tmp_pa
     daemon._handle_server_command(payload)
 
     assert daemon._audio_handler.calls == [(53, True)]
+
+
+def test_set_static_delay_uses_applied_tracker_for_delta(tmp_path: Path) -> None:
+    """Sync delta is computed from `_static_delay_ms`, not stale settings.
+
+    Reproduces the CLI-override case: settings stays at 0 while the client was
+    initialized to 500 from `--static-delay-ms`. A server-initiated delay change
+    to 200 must produce delta = -300ms (200 - 500), not -200ms (200 - 0).
+    """
+    daemon = _make_daemon(tmp_path, settings_volume=25, settings_muted=False)
+    daemon._audio_handler = _FakeAudioHandler(volume=25, muted=False)
+    daemon._static_delay_ms = 500.0
+    # aiosendspin auto-applies before the callback fires, so the client already
+    # reports the new value.
+    daemon._client = SimpleNamespace(static_delay_ms=200.0)  # type: ignore[assignment]
+
+    payload = SimpleNamespace(
+        player=SimpleNamespace(
+            command=PlayerCommand.SET_STATIC_DELAY,
+            volume=None,
+            mute=None,
+            static_delay_ms=200,
+        )
+    )
+
+    # `settings.update` schedules a debounced save via asyncio; wrap in a loop.
+    async def run() -> None:
+        daemon._handle_server_command(payload)
+
+    asyncio.run(run())
+
+    assert daemon._audio_handler.delay_changes == [-300_000]
+    assert daemon._static_delay_ms == 200.0
+    assert daemon._settings.static_delay_ms == 200.0

--- a/tests/tui/test_volume_state.py
+++ b/tests/tui/test_volume_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,19 +16,31 @@ class _FakeAudioHandler:
         self.volume = volume
         self.muted = muted
         self.calls: list[tuple[int, bool]] = []
+        self.delay_changes: list[int] = []
+        self.send_player_volume_calls = 0
 
     def set_volume(self, volume: int, *, muted: bool) -> None:
         self.calls.append((volume, muted))
         self.volume = volume
         self.muted = muted
 
+    def notify_delay_change(self, delta_us: int) -> None:
+        self.delay_changes.append(delta_us)
+
+    def send_player_volume(self) -> None:
+        self.send_player_volume_calls += 1
+
 
 class _FakeUI:
     def __init__(self) -> None:
         self.events: list[str] = []
+        self.delays: list[float] = []
 
     def add_event(self, event: str) -> None:
         self.events.append(event)
+
+    def set_delay(self, delay_ms: float) -> None:
+        self.delays.append(delay_ms)
 
 
 def _make_settings(tmp_path: Path) -> ClientSettings:
@@ -75,6 +88,42 @@ def test_tui_mute_command_uses_audio_handler_volume_state(tmp_path: Path) -> Non
     assert app._audio_handler.calls == [(53, True)]
 
 
+def test_tui_set_static_delay_uses_applied_tracker_for_delta(tmp_path: Path) -> None:
+    """Sync delta is computed from `_applied_delay_ms`, not stale settings.
+
+    Reproduces the CLI-override case: settings stays at 0 while the client was
+    initialized to 500 from `--static-delay-ms`. A server-initiated delay change
+    to 200 must produce delta = -300ms (200 - 500), not -200ms (200 - 0).
+    """
+    app = _make_app(tmp_path)
+    app._audio_handler = _FakeAudioHandler(volume=25, muted=False)
+    app._ui = _FakeUI()
+    app._applied_delay_ms = 500.0
+    # aiosendspin auto-applies before the callback fires, so the client already
+    # reports the new value.
+    app._client = SimpleNamespace(static_delay_ms=200.0)
+
+    payload = SimpleNamespace(
+        player=SimpleNamespace(
+            command=PlayerCommand.SET_STATIC_DELAY,
+            volume=None,
+            mute=None,
+            static_delay_ms=200,
+        )
+    )
+
+    # `settings.update` schedules a debounced save via asyncio; wrap in a loop.
+    async def run() -> None:
+        app._handle_server_command(payload)
+
+    asyncio.run(run())
+
+    assert app._audio_handler.delay_changes == [-300_000]
+    assert app._applied_delay_ms == 200.0
+    assert app._ui.delays == [200.0]
+    assert app._settings.static_delay_ms == 200.0
+
+
 def test_keyboard_volume_change_uses_audio_handler_state(tmp_path: Path) -> None:
     state = AppState(player_volume=10, player_muted=True)
     audio_handler = _FakeAudioHandler(volume=41, muted=False)
@@ -107,3 +156,35 @@ def test_keyboard_toggle_mute_uses_audio_handler_state(tmp_path: Path) -> None:
     handler.toggle_player_mute()
 
     assert audio_handler.calls == [(41, True)]
+
+
+def test_keyboard_adjust_delay_notifies_app_tracker(tmp_path: Path) -> None:
+    """Local `,`/`.` adjustments propagate to the app's applied-delay tracker.
+
+    Without this, a later visualizer toggle would rebuild the client from the
+    pre-adjust value, losing the user's tweak.
+    """
+    audio_handler = _FakeAudioHandler(volume=50, muted=False)
+    ui = _FakeUI()
+    captured: list[float] = []
+    client = SimpleNamespace(static_delay_ms=0.0)
+
+    def set_static_delay_ms(value: float) -> None:
+        client.static_delay_ms = max(0.0, min(5000.0, value))
+
+    client.set_static_delay_ms = set_static_delay_ms
+
+    handler = CommandHandler(
+        get_client=lambda: client,
+        state=AppState(),
+        audio_handler=audio_handler,
+        ui=ui,
+        settings=_make_settings(tmp_path),
+        on_delay_changed=captured.append,
+    )
+
+    asyncio.run(handler.adjust_delay(50))
+
+    assert client.static_delay_ms == 50.0
+    assert audio_handler.delay_changes == [50_000]
+    assert captured == [50.0]


### PR DESCRIPTION
Server-initiated `set_static_delay` computed the audio sync delta from `settings.static_delay_ms`, which can lag the client's real delay when `--static-delay-ms` overrides settings or after a visualizer toggle. The audio worker then got a wrong correction.