### PR TITLE
Fix `sendspin serve` crash on Python 3.12

### DIFF
--- a/sendspin/serve/server.py
+++ b/sendspin/serve/server.py
@@ -1,5 +1,7 @@
 """Custom SendspinServer with embedded web player."""
 
+from __future__ import annotations
+
 from importlib.resources import files
 from multiprocessing.sharedctypes import Synchronized
 from pathlib import Path


### PR DESCRIPTION
`sendspin serve` raised `TypeError: type 'Synchronized' is not subscriptable` at import time on Python 3.12 because `multiprocessing.sharedctypes.Synchronized[int]` only gained `__class_getitem__` in 3.13.