### PR TITLE
Run pytest in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies and run linting
+# This workflow will install Python dependencies and run linting and tests
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Test
@@ -24,3 +24,5 @@ jobs:
         run: uv sync --extra test
       - name: Lint/test with pre-commit
         run: SKIP=no-commit-to-branch uv run pre-commit run --all-files
+      - name: Test with pytest
+        run: uv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,20 @@ jobs:
         run: uv python install 3.12
       - name: Install dependencies
         run: uv sync --extra test
-      - name: Lint/test with pre-commit
+      - name: Lint with pre-commit
         run: SKIP=no-commit-to-branch uv run pre-commit run --all-files
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.3.1
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --extra test
       - name: Test with pytest
         run: uv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v6.0.2
+      - name: Install PortAudio
+        run: sudo apt-get update && sudo apt-get install -y libportaudio2
       - name: Install uv
         uses: astral-sh/setup-uv@v7.3.1
       - name: Set up Python


### PR DESCRIPTION
CI installed the test extras but only ran pre-commit, so the test suite never ran on PRs. The workflow now has separate `lint` and `test` jobs that run in parallel and report as independent status checks.